### PR TITLE
feat: Drop pattern, HTML class name ownership, Nokogiri tests

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -75,6 +75,34 @@ BaseRenderer                  # Core HTML rendering, document assembly, CSS/JS p
     └── RiboseRenderer        # Ribose-specific formatting
 ....
 
+===== Drop Pattern
+
+Block elements (notes, examples, sourcecode, formulas, figures, admonitions) use the Drop pattern:
+
+[source,ruby]
+# A Drop captures rendered content via RendererContext, then passes
+# data to a Liquid template. The renderer never emits HTML directly.
+def render_note(note, **_opts)
+  drop = Drops::NoteDrop.from_model(note, renderer: renderer_context)
+  @output << render_liquid("_note.html.liquid", { "block" => drop })
+end
+
+Each Drop class inherits from `BlockElementDrop` and implements `.from_model(model, renderer:)` which:
+
+. Captures child content via `renderer.capture_output { ... }`
+. Returns a new Drop instance with pre-rendered HTML strings
+. The Liquid template reads Drop attributes and outputs final HTML
+
+`RendererContext` is a facade that exposes only the rendering methods Drops need, maintaining encapsulation.
+
+===== Class Name Ownership
+
+The HTML renderer owns its class names entirely. **No XML-originated class names appear in the HTML output.**
+
+* Block-level classes (`note-block`, `formula`, `figure`, etc.) are assigned by the renderer based on what it's rendering
+* Inline span classes use `SPAN_ROLE_CLASSES` to map XML span roles to HTML-specific names (e.g., `boldtitle` → `title-text`, `citesec` → `xref-section`)
+* The XML's `class_attr` is read as **input only** to determine semantic role, never emitted directly
+
 ==== Presentation XML
 
 The HTML renderer expects **presentation XML** (not source XML). Presentation XML contains `fmt-*` display elements (`fmt-title`, `fmt-xref`, `fmt-link`, `fmt-concept`, `fmt-definition`, `fmt-preferred`, etc.) alongside semantic elements. The renderer prioritizes `fmt-*` elements for rendering, falling back to semantic elements when display elements are absent.
@@ -107,8 +135,15 @@ HTML structure is defined in `.liquid` templates under `lib/metanorma/html/templ
 `_header.html.liquid` :: Sticky header with publisher logos
 `_footer.html.liquid` :: Footer with copyright
 `_cover.html.liquid` :: Cover page layout
+`_iso_cover.html.liquid` :: ISO-specific cover page
 `_footnotes.html.liquid` :: Footnotes section
 `_doc_title.html.liquid` :: Document title rendering
+`_note.html.liquid` :: Note block
+`_example.html.liquid` :: Example block
+`_sourcecode.html.liquid` :: Source code block
+`_formula.html.liquid` :: Formula block
+`_figure.html.liquid` :: Figure block
+`_admonition.html.liquid` :: Admonition block
 
 Templates use `Liquid::LocalFileSystem` for partials (prefixed with `_`). The `render_liquid` method handles template caching via `TEMPLATE_CACHE`.
 
@@ -151,26 +186,32 @@ Renderer instance methods:
 `theme` :: Returns the `Theme` instance (override in subclasses).
 `render_liquid(template_name, assigns)` :: Renders a Liquid template with caching.
 
- == Document Flavors
+== Document Flavors
 
- The gem provides a hierarchy of document flavors:
+The gem provides a hierarchy of document flavors:
 
- * BasicDocument - Basic document model
- * StandardDocument - Standard document model (extends BasicDocument)
- * IsoDocument - ISO standard document model (extends StandardDocument)
- * IecDocument - IEC standard document model
- * IeeeDocument - IEEE standard document model
- * IetfDocument - IETF standard document model
- * IhoDocument - IHO standard document model
- * OimlDocument - OIML standard document model
- * BipmDocument - BIPM standard document model
- * ItuDocument - ITU standard document model
- * OgcDocument - OGC standard document model
- * CcDocument - CC standard document model
- * RiboseDocument - Ribose standard document model
+* BasicDocument - Basic document model
+* StandardDocument - Standard document model (extends BasicDocument)
+* IsoDocument - ISO standard document model (extends StandardDocument)
+* IecDocument - IEC standard document model
+* IeeeDocument - IEEE standard document model
+* IetfDocument - IETF standard document model
+* IhoDocument - IHO standard document model
+* OimlDocument - OIML standard document model
+* BipmDocument - BIPM standard document model
+* ItuDocument - ITU standard document model
+* OgcDocument - OGC standard document model
+* CcDocument - CC standard document model
+* RiboseDocument - Ribose standard document model
 
- == Supported XML Formats
+== Supported XML Formats
 
- This library targets the modern Metanorma XML format which uses `<metanorma>` as the root element.
+This library targets the modern Metanorma XML format which uses `<metanorma>` as the root element.
 
- Legacy XML formats that use flavor-specific root elements (e.g. `<iso-standard>`, `<m3d-standard>`, `<csa-standard>`, `<un-standard>`) are *not supported*.
+Legacy XML formats that use flavor-specific root elements (e.g. `<iso-standard>`, `<m3d-standard>`, `<csa-standard>`, `<un-standard>`) are *not supported*.
+
+== Documentation
+
+Detailed architecture documentation is in the `docs/` directory:
+
+* xref:docs/html-renderer.adoc[HTML Renderer Architecture] — renderer pipeline, drop pattern, class name ownership, template system

--- a/data/stylesheets/components/bibliography.css
+++ b/data/stylesheets/components/bibliography.css
@@ -12,7 +12,7 @@
   border-bottom: 1px solid var(--color-border);
 }
 .norm-ref-entry:last-child { border-bottom-color: transparent; }
-.std-doc-number { font-weight: 500; color: var(--mn-primary); font-family: var(--font-sans); }
-.std-year { font-weight: 500; }
+.ref-doc-number { font-weight: 500; color: var(--mn-primary); font-family: var(--font-sans); }
+.ref-year { font-weight: 500; }
 .biblio-link { color: inherit; text-decoration: none; }
 .biblio-link:hover { color: var(--mn-primary); text-decoration: underline; }

--- a/data/stylesheets/components/inline.css
+++ b/data/stylesheets/components/inline.css
@@ -1,8 +1,8 @@
 /* === Inline Elements === */
 .fn-marker { vertical-align: super; font-size: 0.78em; color: var(--mn-primary); font-family: var(--font-sans); }
 .small-caps { font-variant: small-caps; letter-spacing: 0.03em; }
-.obligation { font-style: italic; color: var(--mn-accent); }
-.bold-title { font-weight: 700; }
+.obligation-text { font-style: italic; color: var(--mn-accent); }
+.title-text { font-weight: 700; }
 
 /* Math container — hover dropdown for source formats */
 .math-container { position: relative; display: inline; }
@@ -30,28 +30,27 @@
   border-radius: 2px; transition: background 0.15s, color 0.15s;
 }
 .stem-copy-btn:hover { background: var(--mn-primary-light); color: var(--mn-primary); }
-.nonboldtitle { font-weight: 400; }
+.subtitle-text { font-weight: 400; }
 
-.citesec, .citefig, .citetbl, .citeapp {
+.xref-section, .xref-fig, .xref-table, .xref-app {
   color: var(--mn-primary);
   text-decoration: underline;
   text-decoration-color: rgba(40,56,138,0.2);
   cursor: pointer;
 }
-.citesec:hover, .citefig:hover, .citetbl:hover, .citeapp:hover {
+.xref-section:hover, .xref-fig:hover, .xref-table:hover, .xref-app:hover {
   color: var(--mn-accent);
 }
 
-.doc-subtitle { font-weight: 400; }
-.doc-part-number { font-weight: 500; }
-.doc-part-title { font-style: italic; }
-.doc-publisher, .doc-publisher-name { font-weight: 500; }
-.std-doc-number { font-weight: 500; }
-.std-year { font-weight: 500; }
+.ref-part-number { font-weight: 500; }
+.ref-title { font-style: italic; }
+.ref-publisher, .ref-publisher-name { font-weight: 500; }
+.ref-doc-number { font-weight: 500; }
+.ref-year { font-weight: 500; }
 .xref-label { font-weight: 600; }
 a.xref { color: var(--mn-primary); text-decoration: none; border-bottom: 1px solid var(--mn-primary-light); }
 a.xref:hover { border-bottom-color: var(--mn-primary); }
-.doc-content a.xref .element-name { font-style: italic; }
+.doc-content a.xref .element-label { font-style: italic; }
 
 .kbd-hint {
   display: inline-block;

--- a/docs/html-renderer.adoc
+++ b/docs/html-renderer.adoc
@@ -1,0 +1,261 @@
+= HTML Renderer Architecture
+
+== Overview
+
+The HTML renderer converts a Metanorma document model (parsed from presentation XML) into a complete, self-contained HTML document. It produces all body content, header, footer, table of contents, CSS theming, and JavaScript interactivity.
+
+== Pipeline
+
+....
+Generator.generate(doc)
+  ├── Auto-selects renderer by document class
+  ├── Renderer.new
+  └── renderer.generate_full_document(doc)
+        ├── Header (publisher logos, document title)
+        ├── ToC sidebar
+        ├── Body content (recursive render)
+        ├── Footnotes
+        ├── Footer (copyright)
+        └── Asset pipeline (inline CSS + JS)
+....
+
+== Renderer Hierarchy
+
+[source,ruby]
+BaseRenderer                  # Core HTML rendering, document assembly, CSS/JS pipeline
+└── StandardRenderer          # Terms, definitions, annexes, bibliography
+    ├── IsoRenderer           # ISO cover page, copyright, title formatting
+    │   ├── IccRenderer       # ICC publisher styling
+    │   └── PdfaRenderer      # PDF Association publisher styling
+    ├── IecRenderer           # IEC-specific formatting
+    ├── IeeeRenderer          # IEEE-specific formatting
+    ├── IetfRenderer          # IETF-specific formatting
+    ├── IhoRenderer           # IHO-specific formatting
+    ├── ItuRenderer           # ITU-specific formatting
+    ├── OgcRenderer           # OGC-specific formatting
+    ├── OimlRenderer          # OIML-specific formatting
+    ├── BipmRenderer          # BIPM-specific formatting
+    ├── CcRenderer            # CC-specific formatting
+    └── RiboseRenderer        # Ribose-specific formatting
+
+=== Renderer Selection
+
+The `Generator` uses a two-tier lookup:
+
+1. **Taste match**: If the document's publisher matches a registered taste, use that renderer.
+2. **Model class**: Walk the ancestor chain from most specific to `BaseRenderer`.
+
+[source,ruby]
+# ICC documents are IsoDocument::Root but use IccRenderer
+Metanorma::Html::Generator.register_taste(
+  Metanorma::IsoDocument::Root,
+  "ICC",
+  Metanorma::Html::IccRenderer
+)
+
+== Class Name Ownership
+
+The HTML renderer owns its class names entirely. **No XML-originated class names appear in the HTML output.**
+
+The XML document model's `class_attr` is read as **input only** to determine semantic role. The renderer maps XML roles to HTML-specific class names via `SPAN_ROLE_CLASSES`:
+
+[source,ruby]
+SPAN_ROLE_CLASSES = {
+  "boldtitle" => "title-text",
+  "citefig" => "xref-fig",
+  "citesec" => "xref-section",
+  "fmt-element-name" => "element-label",
+  "fmt-obligation" => "obligation-text",
+  # ...
+}.freeze
+
+Block-level classes (`note-block`, `formula`, `figure`, etc.) are assigned by the renderer based on what it's rendering — never carried over from XML.
+
+Inline span classes go through `html_class_for_span`:
+
+[source,ruby]
+def html_class_for_span(xml_class)
+  SPAN_ROLE_CLASSES[xml_class] || "span-#{xml_class}"
+end
+
+Raw XML content (e.g., boilerplate) passes through Nokogiri post-processing that remaps any remaining XML class names.
+
+== Drop Pattern
+
+Block elements (notes, examples, sourcecode, formulas, figures, admonitions) use the Drop pattern to separate data capture from template rendering.
+
+=== How It Works
+
+. A `Drop` class captures rendered content via `RendererContext`
+. The Drop passes pre-rendered HTML strings to a Liquid template
+. The template reads Drop attributes and outputs final HTML
+
+[source,ruby]
+# In the renderer:
+def render_note(note, **_opts)
+  drop = Drops::NoteDrop.from_model(note, renderer: renderer_context)
+  @output << render_liquid("_note.html.liquid", { "block" => drop })
+end
+
+# In the Drop:
+class NoteDrop < BlockElementDrop
+  def self.from_model(note, renderer:)
+    content_html = renderer.capture_output do
+      note.content.each { |para| renderer.render_paragraph(para) }
+    end
+    new(id: renderer.safe_attr(note, :id),
+        label_html: renderer.escape_html(label),
+        content_html: content_html,
+        css_class: "note-block")
+  end
+end
+
+=== BlockElementDrop
+
+All block drops inherit from `BlockElementDrop`, which provides common attributes:
+
+`id` :: HTML element id
+`type` :: Block type identifier
+`label_html` :: Pre-rendered label (e.g., "NOTE", "EXAMPLE 1")
+`content_html` :: Pre-rendered inner content
+`css_class` :: HTML-specific class name
+
+=== RendererContext
+
+`RendererContext` is a facade inside `BaseRenderer` that exposes only the rendering methods Drops need. Drops call renderer methods through this facade — the renderer's private interface stays encapsulated.
+
+[source,ruby]
+class RendererContext
+  def safe_attr(obj, method_name)
+  def escape_html(text)
+  def extract_block_label(block, default)
+  def extract_plain_text(node)
+  def capture_output(&block)
+  def render_paragraph(p)
+  def render_mixed_inline(node)
+  def render_inline_element(el)
+  def render_unordered_list(ul)
+  def render_ordered_list(ol)
+  def render_definition_list(dl)
+  def render_table(table)
+  def render_figure(figure)
+end
+
+== Liquid Templates
+
+HTML structure is defined in `.liquid` templates under `lib/metanorma/html/templates/`.
+
+[horizontal]
+`document.html.liquid` :: Full document shell (`<html>`, `<head>`, `<body>`)
+`_header.html.liquid` :: Sticky header with publisher logos
+`_footer.html.liquid` :: Footer with copyright
+`_cover.html.liquid` :: Generic cover page layout
+`_iso_cover.html.liquid` :: ISO-specific cover page
+`_iso_doc_title.html.liquid` :: ISO document title rendering
+`_doc_title.html.liquid` :: Generic document title rendering
+`_footnotes.html.liquid` :: Footnotes section
+`_note.html.liquid` :: Note block
+`_example.html.liquid` :: Example block
+`_sourcecode.html.liquid` :: Source code block
+`_formula.html.liquid` :: Formula block
+`_figure.html.liquid` :: Figure block
+`_admonition.html.liquid` :: Admonition block
+
+Templates use `Liquid::LocalFileSystem` for partials (prefixed with `_`). The `render_liquid` method handles template caching.
+
+=== Template Example
+
+`_note.html.liquid`:
+
+[source,liquid]
+----
+<div{% if block.id %} id="{{ block.id }}"{% endif %} class="{{ block.css_class }}">
+  {% if block.label_html %}
+  <p class="note-label"><strong>{{ block.label_html }}</strong></p>
+  {% endif %}
+  <div class="note-content">
+    {{ block.content_html }}
+  </div>
+</div>
+----
+
+== Theming
+
+Each renderer has a `Theme` object controlling colors, typography, and layout. Theme properties are emitted as CSS custom properties (`--mn-primary`, `--font-body`, etc.).
+
+[source,ruby]
+class MyRenderer < Metanorma::Html::StandardRenderer
+  def theme
+    @theme ||= begin
+      t = Theme.new
+      t.primary = "#1a5276"
+      t.accent = "#2e86c1"
+      t.font_body = '"Charter", serif'
+      t
+    end
+  end
+end
+
+=== Theme Properties
+
+[horizontal]
+`primary` :: Primary brand color
+`accent` :: Accent/highlight color
+`gradient` :: Header gradient
+`font_body` :: Body text font stack
+`font_sans` :: Sans-serif font stack
+`font_mono` :: Monospace font stack
+`font_url` :: Google Fonts URL
+`note_border` :: Note block border color
+`note_bg` :: Note block background
+`example_border` :: Example block border color
+`example_bg` :: Example block background
+`admonition_border` :: Admonition border color
+`admonition_bg` :: Admonition background
+`extra_css` :: Additional CSS string appended after defaults
+
+== Presentation XML
+
+The HTML renderer expects **presentation XML** (not source XML). Presentation XML contains `fmt-*` display elements alongside semantic elements:
+
+- `fmt-title` — formatted section/block titles
+- `fmt-xref` — formatted cross-reference text
+- `fmt-link` — formatted link text
+- `fmt-concept` — formatted concept references
+- `fmt-definition` — formatted term definitions
+- `fmt-preferred` — formatted preferred term names
+
+The renderer prioritizes `fmt-*` elements for rendering, falling back to semantic elements when display elements are absent.
+
+== Asset Pipeline
+
+The `AssetPipeline` compiles CSS and JavaScript from modular source files into inline `<style>` and `<script>` blocks for self-contained output.
+
+=== CSS
+
+[horizontal]
+`data/stylesheets/base/` :: Reset, typography, layout, dark mode, print
+`data/stylesheets/components/` :: Component stylesheets (inline, tables, notes, etc.)
+
+=== JavaScript
+
+[horizontal]
+`data/javascripts/core/` :: Reader, theme, scroll, navigation, reveal
+`data/javascripts/components/` :: ToC, search, lightbox, code copy, glossary, etc.
+
+== Extending
+
+To add a new flavor renderer:
+
+. Subclass the appropriate base (usually `IsoRenderer` or `StandardRenderer`)
+. Override `theme` with brand colors/fonts
+. Override `publisher_logo_map` with logo filenames
+. Register with the Generator:
+
+[source,ruby]
+Metanorma::Html::Generator.register(
+  Metanorma::MyDocument::Root,
+  Metanorma::Html::MyRenderer
+)
+
+To customize how a specific block renders, override the `render_*` method and either emit HTML directly or use the Drop pattern with a new template.

--- a/lib/metanorma/html/base_renderer.rb
+++ b/lib/metanorma/html/base_renderer.rb
@@ -17,43 +17,33 @@ module Metanorma
     class BaseRenderer
       LOGO_DIR = File.expand_path("../../../data/logos", __dir__)
 
-      # Map legacy XML class names to clean, semantic names.
-      CLASS_MAP = {
-        "zzSTDTitle1" => "doc-title",
-        "coverpage_docnumber" => "cover-doc-id",
-        "coverpage_docstage" => "cover-stage",
-        "doctitle-en" => "cover-title",
-        "ForewordTitle" => "foreword-title",
-        "IntroTitle" => "intro-title",
-        "Annex" => "annex-title",
-        "Section3" => "section-sub",
-        "TermNum" => "term-number",
-        "Terms" => "term-name",
-        "DeprecatedTerms" => "term-deprecated",
-        "domain" => "term-domain",
-        "boldtitle" => "bold-title",
-        "note_label" => "note-label",
-        "termnote_label" => "term-note-label",
-        "example_label" => "example-label",
-        "stddocNumber" => "std-doc-number",
-        "stdyear" => "std-year",
-        "sourcecode-name" => "code-name",
+      # HTML-specific class names for inline spans, keyed by the XML span role.
+      # The XML class_attr is INPUT only — we never emit it in HTML.
+      SPAN_ROLE_CLASSES = {
+        "boldtitle" => "title-text",
+        "nonboldtitle" => "subtitle-text",
+        "citeapp" => "xref-app",
+        "citefig" => "xref-fig",
+        "citesec" => "xref-section",
+        "citetbl" => "xref-table",
+        "fmt-autonum-delim" => "number-delim",
         "fmt-caption-label" => "caption-label",
-        "fmt-autonum-delim" => "autonum-delim",
-        "fmt-element-name" => "element-name",
         "fmt-caption-delim" => "caption-delim",
-        "smallcap" => "small-caps",
-        "obligation" => "obligation-text",
-        "tableblock" => "table-block",
-        "Biblio" => "biblio-entry",
-        "Note" => "note-block",
-        "source" => "term-source",
-        "nonboldtitle" => "doc-subtitle",
-        "stddocPartNumber" => "doc-part-number",
-        "stddocTitle" => "doc-part-title",
-        "std_publisher" => "doc-publisher",
-        "stdpublisher" => "doc-publisher-name",
+        "fmt-element-name" => "element-label",
+        "fmt-comma" => "comma",
+        "fmt-conn" => "connector",
+        "fmt-label-delim" => "label-delim",
+        "fmt-obligation" => "obligation-text",
+        "fmt-xref-container" => "xref-container",
         "fmt-xref-label" => "xref-label",
+        "std_publisher" => "ref-publisher",
+        "stdpublisher" => "ref-publisher-name",
+        "stddocNumber" => "ref-doc-number",
+        "stddocTitle" => "ref-title",
+        "stddocPartNumber" => "ref-part-number",
+        "stdyear" => "ref-year",
+        "date" => "date",
+        "smallcap" => "small-caps",
       }.freeze
 
       METANORMA_LOGO = "metanorma-logo.svg"
@@ -70,6 +60,40 @@ module Metanorma
       end
 
       # --- Public API ---
+
+      # Facade object for Drops to call renderer methods without exposing
+      # the full private interface. Delegates to the renderer internally.
+      class RendererContext
+        def initialize(renderer)
+          @renderer = renderer
+        end
+
+        def safe_attr(obj, method_name) = @renderer.send(:safe_attr, obj, method_name)
+        def escape_html(text) = @renderer.send(:escape_html, text)
+        def extract_block_label(block, default) = @renderer.send(:extract_block_label, block, default)
+        def extract_plain_text(node) = @renderer.send(:extract_plain_text, node)
+        def capture_output(&) = @renderer.send(:capture_output, &)
+        def render_paragraph(p) = @renderer.send(:render_paragraph, p)
+        def render_mixed_inline(node) = @renderer.send(:render_mixed_inline, node)
+        def render_inline_element(el) = @renderer.send(:render_inline_element, el)
+        def render_unordered_list(ul) = @renderer.send(:render_unordered_list, ul)
+        def render_ordered_list(ol) = @renderer.send(:render_ordered_list, ol)
+        def render_definition_list(dl) = @renderer.send(:render_definition_list, dl)
+        def render_sourcecode(sc) = @renderer.send(:render_sourcecode, sc)
+        def render_table(t) = @renderer.send(:render_table, t)
+        def render_figure(f) = @renderer.send(:render_figure, f)
+        def render_quote(q) = @renderer.send(:render_quote, q)
+        def render_formula(f) = @renderer.send(:render_formula, f)
+        def render_note(n) = @renderer.send(:render_note, n)
+        def render_image(img) = @renderer.send(:render_image, img)
+        def render_stem_content(stem) = @renderer.send(:render_stem_content, stem)
+        def register_figure_entry(...) = @renderer.send(:register_figure_entry, ...)
+        def render_liquid(template_name, assigns) = @renderer.send(:render_liquid, template_name, assigns)
+      end
+
+      def renderer_context
+        @renderer_context ||= RendererContext.new(self)
+      end
 
       def to_html
         @output
@@ -132,16 +156,16 @@ module Metanorma
         footer = build_footer
 
         render_liquid("document.html.liquid", {
-          "lang" => language,
-          "title" => html_title,
-          "font_url" => flavor_font_url,
-          "styles" => build_styles,
-          "header" => header,
-          "toc" => toc_html,
-          "body" => body,
-          "footer" => footer,
-          "scripts" => build_scripts,
-        })
+                        "lang" => language,
+                        "title" => html_title,
+                        "font_url" => flavor_font_url,
+                        "styles" => build_styles,
+                        "header" => header,
+                        "toc" => toc_html,
+                        "body" => body,
+                        "footer" => footer,
+                        "scripts" => build_scripts,
+                      })
       end
 
       # --- Header and Footer ---
@@ -157,15 +181,15 @@ module Metanorma
                      end
 
         render_liquid("_header.html.liquid", {
-          "publisher_logos" => pub_logos,
-          "doc_id" => display_id,
-          "doc_title" => header_title_text,
-        })
+                        "publisher_logos" => pub_logos,
+                        "doc_id" => display_id,
+                        "doc_title" => header_title_text,
+                      })
       end
 
       def header_title_text
         raw = html_title.to_s.split(" — ").first.to_s.gsub(/<[^>]+>/, "")
-        raw.length > 60 ? raw[0, 57] + "..." : raw
+        raw.length > 60 ? "#{raw[0, 57]}..." : raw
       end
 
       # Reader controls — kept for backward compat with flavor renderers
@@ -205,13 +229,12 @@ module Metanorma
         svg = svg.sub(/\A\s*<!--.*?-->\s*/m, "")
         svg = svg.sub(/<path[^>]*style="fill:#e3000f[^"]*"[^>]*\/>/, "")
         svg = svg.sub(/<svg\s/, '<svg class="header-logo" ')
-        if svg.match?(/<svg[^>]*\sheight="[^"]*"/)
-          svg = svg.sub(/(<svg[^>]*?)(\sheight="[^"]*")/, "\\1 height=\"#{height}\"")
-        else
-          svg = svg.sub(/(<svg\b)/, "\\1 height=\"#{height}\"")
-        end
-        svg = svg.sub(/(<svg[^>]*?)\swidth="[^"]*"/, '\1')
-        svg
+        svg = if svg.match?(/<svg[^>]*\sheight="[^"]*"/)
+                svg.sub(/(<svg[^>]*?)(\sheight="[^"]*")/, "\\1 height=\"#{height}\"")
+              else
+                svg.sub(/(<svg\b)/, "\\1 height=\"#{height}\"")
+              end
+        svg.sub(/(<svg[^>]*?)\swidth="[^"]*"/, '\1')
       rescue StandardError
         nil
       end
@@ -219,9 +242,9 @@ module Metanorma
       def build_footer
         mn_logo = load_logo_svg(METANORMA_LOGO, height: 20)
         render_liquid("_footer.html.liquid", {
-          "mn_logo" => mn_logo,
-          "generated_at" => Time.now.strftime('%Y-%m-%d %H:%M'),
-        })
+                        "mn_logo" => mn_logo,
+                        "generated_at" => Time.now.strftime("%Y-%m-%d %H:%M"),
+                      })
       end
 
       # --- ToC generation ---
@@ -231,32 +254,32 @@ module Metanorma
         main_lines = if entries.empty?
                        ["<li class=\"toc-empty\">No entries</li>"]
                      else
-                       entries.map { |e|
+                       entries.map do |e|
                          id = e[:id].to_s
                          text = escape_html(e[:text].to_s)
                          lvl = e[:level]
                          "<li class=\"toc-level-#{lvl}\"><a href=\"##{id}\" class=\"toc-link\" data-target=\"#{id}\">#{text}</a></li>"
-                       }
+                       end
                      end
 
         # List of Figures — at top of sidebar
         unless @figure_entries.empty?
           top_lines << "<li class=\"toc-list-header\" data-list=\"figures\"><button class=\"toc-list-toggle\" aria-expanded=\"false\"><svg width=\"14\" height=\"14\" viewBox=\"0 0 16 16\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"1.5\"><rect x=\"1\" y=\"2\" width=\"14\" height=\"12\" rx=\"1\"/><circle cx=\"5\" cy=\"6.5\" r=\"1.5\"/><path d=\"M1 12l4-4 2 2 3-3 5 5\"/></svg> Figures <span class=\"toc-list-count\">(#{@figure_entries.size})</span></button></li>"
-          @figure_entries.each { |f|
+          @figure_entries.each do |f|
             id = f[:id].to_s
             text = escape_html(f[:text].to_s)
             top_lines << "<li class=\"toc-list-item toc-figures\" style=\"display:none\"><a href=\"##{id}\" class=\"toc-link\" data-target=\"#{id}\">#{text}</a></li>"
-          }
+          end
         end
 
         # List of Tables — at top of sidebar
         unless @table_entries.empty?
           top_lines << "<li class=\"toc-list-header\" data-list=\"tables\"><button class=\"toc-list-toggle\" aria-expanded=\"false\"><svg width=\"14\" height=\"14\" viewBox=\"0 0 16 16\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"1.5\"><rect x=\"1\" y=\"2\" width=\"14\" height=\"12\" rx=\"1\"/><line x1=\"1\" y1=\"6\" x2=\"15\" y2=\"6\"/><line x1=\"1\" y1=\"10\" x2=\"15\" y2=\"10\"/><line x1=\"7\" y1=\"2\" x2=\"7\" y2=\"14\"/></svg> Tables <span class=\"toc-list-count\">(#{@table_entries.size})</span></button></li>"
-          @table_entries.each { |t|
+          @table_entries.each do |t|
             id = t[:id].to_s
             text = escape_html(t[:text].to_s)
             top_lines << "<li class=\"toc-list-item toc-tables\" style=\"display:none\"><a href=\"##{id}\" class=\"toc-link\" data-target=\"#{id}\">#{text}</a></li>"
-          }
+          end
         end
 
         top_lines << "<li class=\"toc-divider\"></li>" unless top_lines.empty?
@@ -307,12 +330,25 @@ module Metanorma
         end
 
         if node.is_a?(Lutaml::Model::Serializable)
-          return true if (node.public_send(:fmt_title) rescue nil)
-          return true if (node.public_send(:displayorder) rescue nil)
+          return true if begin
+            node.fmt_title
+          rescue StandardError
+            nil
+          end
+          return true if begin
+            node.displayorder
+          rescue StandardError
+            nil
+          end
 
           %i[preface sections annex bibliography].each do |attr|
-            val = node.public_send(attr) rescue nil
+            val = begin
+              node.public_send(attr)
+            rescue StandardError
+              nil
+            end
             next unless val
+
             Array(val).each { |v| return true if check_presentation_markers(v) }
           end
 
@@ -405,6 +441,7 @@ module Metanorma
           indices = Hash.new(0)
           node.element_order.each do |el|
             next unless el.is_a?(Lutaml::Xml::Element)
+
             if el.text?
               parts << el.text_content.to_s
             elsif el.name == "tab"
@@ -434,42 +471,42 @@ module Metanorma
           parts << (t.is_a?(Array) ? t.join : t.to_s) if t
         end
 
-        parts.join.strip.gsub(/\u00A0/, " ")
+        parts.join.strip.gsub("\u00A0", " ")
       end
 
       # Dispatch to the appropriate render method based on node class.
-      def render(node, **opts)
+      def render(node, **)
         case node
         when Metanorma::Document::Components::Paragraphs::ParagraphBlock
-          render_paragraph(node, **opts)
+          render_paragraph(node, **)
         when Metanorma::Document::Components::Tables::TableBlock
-          render_table(node, **opts)
+          render_table(node, **)
         when Metanorma::Document::Components::Lists::UnorderedList
-          render_unordered_list(node, **opts)
+          render_unordered_list(node, **)
         when Metanorma::Document::Components::Lists::OrderedList
-          render_ordered_list(node, **opts)
+          render_ordered_list(node, **)
         when Metanorma::Document::Components::Lists::DefinitionList
-          render_definition_list(node, **opts)
+          render_definition_list(node, **)
         when Metanorma::Document::Components::AncillaryBlocks::FigureBlock
-          render_figure(node, **opts)
+          render_figure(node, **)
         when Metanorma::Document::Components::Blocks::NoteBlock
-          render_note(node, **opts)
+          render_note(node, **)
         when Metanorma::Document::Components::AncillaryBlocks::ExampleBlock
-          render_example(node, **opts)
+          render_example(node, **)
         when Metanorma::Document::Components::AncillaryBlocks::SourcecodeBlock
-          render_sourcecode(node, **opts)
+          render_sourcecode(node, **)
         when Metanorma::Document::Components::AncillaryBlocks::FormulaBlock
-          render_formula(node, **opts)
+          render_formula(node, **)
         when Metanorma::Document::Components::MultiParagraph::QuoteBlock
-          render_quote(node, **opts)
+          render_quote(node, **)
         when Metanorma::Document::Components::MultiParagraph::AdmonitionBlock
-          render_admonition(node, **opts)
+          render_admonition(node, **)
         when Metanorma::Document::Components::Sections::HierarchicalSection
-          render_hierarchical_section(node, **opts)
+          render_hierarchical_section(node, **)
         when Metanorma::Document::Components::Sections::BasicSection
-          render_basic_section(node, **opts)
+          render_basic_section(node, **)
         when Metanorma::Document::Components::Sections::ContentSection
-          render_content_section(node, **opts)
+          render_content_section(node, **)
         when Metanorma::Document::Components::EmptyElements::PageBreakElement
           ""
         when Metanorma::Document::Components::IdElements::Bookmark
@@ -488,7 +525,7 @@ module Metanorma
       # --- Block-level rendering ---
 
       def render_paragraph(p, **_opts)
-        attrs = element_attrs(id: safe_attr(p, :id), class: safe_attr(p, :class_attr), style: alignment_style(safe_attr(p, :alignment)))
+        attrs = element_attrs(id: safe_attr(p, :id), style: alignment_style(safe_attr(p, :alignment)))
         tag("p", attrs) { render_mixed_inline(p) }
       end
 
@@ -531,19 +568,21 @@ module Metanorma
         if table.colgroup&.col && !table.colgroup.col.empty?
           return table.colgroup.col.size
         end
+
         # Walk all rows to find max column count, accounting for colspan
         max_cols = 0
-        [:thead, :tbody, :tfoot].each do |section|
+        %i[thead tbody tfoot].each do |section|
           sec = table.public_send(section)
           next unless sec&.tr
+
           sec.tr.each do |tr|
             cols = 0
-            Array(tr.th).each { |th| cols += (th.colspan && th.colspan > 1) ? th.colspan : 1 }
-            Array(tr.td).each { |td| cols += (td.colspan && td.colspan > 1) ? td.colspan : 1 }
+            Array(tr.th).each { |th| cols += th.colspan && th.colspan > 1 ? th.colspan : 1 }
+            Array(tr.td).each { |td| cols += td.colspan && td.colspan > 1 ? td.colspan : 1 }
             max_cols = cols if cols > max_cols
           end
         end
-        max_cols > 0 ? max_cols : 1
+        max_cols.positive? ? max_cols : 1
       end
 
       def render_table_colgroup(colgroup)
@@ -564,6 +603,7 @@ module Metanorma
           @output << "<tr>"
           walked = walk_ordered(tr) do |type, obj|
             next unless type == :element
+
             render_table_cell(obj)
           end
           unless walked
@@ -575,7 +615,7 @@ module Metanorma
       end
 
       def render_unordered_list(ul, **_opts)
-        attrs = element_attrs(id: safe_attr(ul, :id), class: safe_attr(ul, :class_attr))
+        attrs = element_attrs(id: safe_attr(ul, :id))
         tag("ul", attrs) do
           ul.listitem&.each { |li| render_list_item(li) }
         end
@@ -595,7 +635,7 @@ module Metanorma
       end
 
       def render_ordered_list(ol, **_opts)
-        attrs = element_attrs(id: safe_attr(ol, :id), class: safe_attr(ol, :class_attr), start: safe_attr(ol, :start), type: safe_attr(ol, :type_attr))
+        attrs = element_attrs(id: safe_attr(ol, :id), start: safe_attr(ol, :start), type: safe_attr(ol, :type_attr))
         tag("ol", attrs) do
           ol.listitem&.each { |li| render_list_item(li) }
         end
@@ -634,7 +674,8 @@ module Metanorma
         children = []
 
         walk_ordered(section) do |type, obj|
-          next if type == :text || type == :tab
+          next if %i[text tab].include?(type)
+
           children << obj
         end
 
@@ -643,6 +684,7 @@ module Metanorma
         supplementary_attrs.each do |attr|
           val = safe_attr(section, attr)
           next if val.nil?
+
           Array(val).each do |v|
             children << v unless children.include?(v)
           end
@@ -665,7 +707,11 @@ module Metanorma
 
       def sort_by_displayorder(children)
         children.sort_by do |node|
-          order = node.displayorder rescue nil
+          order = begin
+            node.displayorder
+          rescue StandardError
+            nil
+          end
           order &&= order.to_i
           order || Float::INFINITY
         end
@@ -689,29 +735,8 @@ module Metanorma
       end
 
       def render_figure(figure, **_opts)
-        attrs = element_attrs(id: safe_attr(figure, :id), class: "figure")
-        fig_id = safe_attr(figure, :id)
-        fig_name = safe_attr(figure, :fmt_name) || safe_attr(figure, :name)
-        if fig_id && fig_name
-          register_figure_entry(id: fig_id, text: extract_plain_text(fig_name))
-        end
-        tag("figure", attrs) do
-          if figure.image
-            render_image(figure.image)
-          elsif safe_attr(figure, :source)
-            @output << %(<img src="#{escape_html(figure.source)}" />)
-          end
-          render_video(figure.video) if safe_attr(figure, :video)
-          render_audio(figure.audio) if safe_attr(figure, :audio)
-          figure.figure&.each { |sub| render_figure(sub) }
-          if safe_attr(figure, :name) || safe_attr(figure, :fmt_name)
-            @output << "<figcaption>"
-            render_inline_element(safe_attr(figure, :fmt_name) || figure.name)
-            @output << "</figcaption>"
-          end
-          safe_attr(figure, :note)&.each { |n| render_note(n) }
-          safe_attr(figure, :dl)&.then { |dl| render_definition_list(dl) }
-        end
+        drop = Drops::FigureDrop.from_model(figure, renderer: renderer_context)
+        @output << render_liquid("_figure.html.liquid", { "block" => drop })
       end
 
       def render_image(image)
@@ -743,91 +768,23 @@ module Metanorma
       end
 
       def render_note(note, **_opts)
-        attrs = element_attrs(id: safe_attr(note, :id), class: "note-block")
-        tag("div", attrs) do
-          label = extract_block_label(note, "NOTE")
-          @output << %(<span class="note-label">#{escape_html(label)}</span>&nbsp;)
-          if note.content && !note.content.empty?
-            note.content.each { |para| render_paragraph(para) }
-          else
-            render_mixed_inline(note)
-          end
-          note.ul&.each { |ul| render_unordered_list(ul) }
-          note.ol&.each { |ol| render_ordered_list(ol) }
-          note.dl&.then { |dl| render_definition_list(dl) }
-        end
+        drop = Drops::NoteDrop.from_model(note, renderer: renderer_context)
+        @output << render_liquid("_note.html.liquid", { "block" => drop })
       end
 
       def render_example(example, **_opts)
-        attrs = element_attrs(id: safe_attr(example, :id), class: "example")
-        tag("div", attrs) do
-          label = extract_block_label(example, "EXAMPLE")
-          @output << %(<span class="example-label">#{escape_html(label)}</span>&nbsp;)
-          if example.paragraphs && !example.paragraphs.empty?
-            example.paragraphs.each { |para| render_paragraph(para) }
-          end
-          example.ul&.each { |ul| render_unordered_list(ul) }
-          example.ol&.each { |ol| render_ordered_list(ol) }
-          example.dl&.each { |dl| render_definition_list(dl) } if example.dl
-          example.sourcecode&.each { |sc| render_sourcecode(sc) }
-          example.table&.each { |t| render_table(t) }
-          example.figure&.each { |f| render_figure(f) }
-          example.quote&.each { |q| render_quote(q) }
-          example.formula&.each { |f| render_formula(f) }
-        end
+        drop = Drops::ExampleDrop.from_model(example, renderer: renderer_context)
+        @output << render_liquid("_example.html.liquid", { "block" => drop })
       end
 
       def render_sourcecode(sc, **_opts)
-        attrs = element_attrs(id: safe_attr(sc, :id), class: "sourcecode")
-        lang = safe_attr(sc, :lang)
-        tag("div", attrs) do
-          if sc.name
-            @output << "<p class=\"code-name\">"
-            render_inline_element(sc.name)
-            @output << "</p>"
-          end
-          code_attrs = lang ? %( lang="#{escape_html(lang)}") : ""
-          @output << "<pre><code#{code_attrs}>"
-          # Use body.content if available, else content, else text
-          code_text = if sc.body && sc.body.content
-                        sc.body.content
-                      elsif sc.content
-                        sc.content
-                      else
-                        ""
-                      end
-          # body.content from map_all_content may contain pre-escaped HTML
-          # entities (&lt; etc); decode first to get raw text, then escape
-          # for HTML output.
-          raw_text = code_text.gsub("&lt;", "<").gsub("&gt;", ">").gsub("&amp;", "&").gsub("&quot;", "\"")
-          @output << escape_html(raw_text)
-          @output << "</code></pre>"
-        end
+        drop = Drops::SourcecodeDrop.from_model(sc, renderer: renderer_context)
+        @output << render_liquid("_sourcecode.html.liquid", { "block" => drop })
       end
 
       def render_formula(formula, **_opts)
-        attrs = element_attrs(id: safe_attr(formula, :id), class: "formula")
-        tag("div", attrs) do
-          @output << render_stem_content(formula.stem) if formula.stem
-
-          # Render "where" clause from key element (non-presentation XML)
-          if formula.key
-            if formula.key.dl
-              @output << "<p class=\"formula-where\">where</p>"
-              render_definition_list(formula.key.dl)
-            end
-            formula.key.p&.each { |para| render_paragraph(para) }
-          end
-
-          formula.dl&.then { |dl| render_definition_list(dl) }
-
-          name_el = safe_attr(formula, :fmt_name) || safe_attr(formula, :name)
-          if name_el
-            @output << "<span class=\"formula-number\">"
-            render_inline_element(name_el)
-            @output << "</span>"
-          end
-        end
+        drop = Drops::FormulaDrop.from_model(formula, renderer: renderer_context)
+        @output << render_liquid("_formula.html.liquid", { "block" => drop })
       end
 
       def render_quote(quote, **_opts)
@@ -845,12 +802,8 @@ module Metanorma
       end
 
       def render_admonition(admonition, **_opts)
-        type = safe_attr(admonition, :type) || "note"
-        attrs = element_attrs(id: safe_attr(admonition, :id), class: "admonition #{type}")
-        tag("div", attrs) do
-          @output << "<p class=\"admonition-title\">#{escape_html(type.capitalize)}</p>"
-          admonition.paragraphs&.each { |para| render_paragraph(para) }
-        end
+        drop = Drops::AdmonitionDrop.from_model(admonition, renderer: renderer_context)
+        @output << render_liquid("_admonition.html.liquid", { "block" => drop })
       end
 
       def render_bookmark(bookmark)
@@ -973,13 +926,14 @@ module Metanorma
         skip = {}
         node.element_order.each_with_index do |el, i|
           next unless el.element?
+
           next_tag = skip_after[el.name]
           next unless next_tag
 
           next_el = node.element_order[i + 1]
           if next_tag.nil?
             skip[i] = true
-          elsif next_el && next_el.element? && next_el.name == next_tag
+          elsif next_el&.element? && next_el.name == next_tag
             skip[i] = true
           end
         end
@@ -1107,7 +1061,9 @@ module Metanorma
           # Source element — skip; rendered via fmt-xref in semx wrapper
           nil
         when Metanorma::Document::Components::Inline::SpanElement
-          attrs = element_attrs(style: safe_attr(element, :style), class: safe_attr(element, :class_attr))
+          xml_class = safe_attr(element, :class_attr).to_s
+          html_class = html_class_for_span(xml_class) unless xml_class.empty?
+          attrs = element_attrs(style: safe_attr(element, :style), class: html_class)
           tag("span", attrs) { render_mixed_inline(element) }
         when Metanorma::Document::Components::Inline::FnElement
           render_fn(element)
@@ -1183,13 +1139,13 @@ module Metanorma
         texts = node.text
         if texts.is_a?(Array)
           texts.each do |t|
-            if t.is_a?(Metanorma::Document::Components::Inline::MathElement)
-              @output << t.content.to_s
-            elsif t.is_a?(Metanorma::Document::Components::Inline::AsciimathElement)
-              @output << %(<span class="stem">#{escape_html(Array(t.text).join)}</span>)
-            else
-              @output << escape_html(t.to_s)
-            end
+            @output << if t.is_a?(Metanorma::Document::Components::Inline::MathElement)
+                         t.content.to_s
+                       elsif t.is_a?(Metanorma::Document::Components::Inline::AsciimathElement)
+                         %(<span class="stem">#{escape_html(Array(t.text).join)}</span>)
+                       else
+                         escape_html(t.to_s)
+                       end
           end
         elsif texts.is_a?(String)
           @output << escape_html(texts)
@@ -1239,6 +1195,7 @@ module Metanorma
           display_attrs.each do |attr|
             val = safe_attr(element, attr)
             next if val.nil?
+
             if val.is_a?(Array)
               val.each do |v|
                 if v.is_a?(Metanorma::Document::Components::Paragraphs::ParagraphBlock)
@@ -1261,7 +1218,7 @@ module Metanorma
         return semx_text unless first_word
 
         tail = output[-200..]
-        return semx_text unless tail && tail.rstrip.end_with?(first_word)
+        return semx_text unless tail&.rstrip&.end_with?(first_word)
 
         semx_text.sub(/\A\s*#{Regexp.escape(first_word)}\s*/, "")
       end
@@ -1279,7 +1236,7 @@ module Metanorma
         doc.css("fmt-link").each do |el|
           target = el["target"] || el["href"]
           if target
-            display_text = target.sub(/\Amailto:/, "")
+            display_text = target.delete_prefix("mailto:")
             a = doc.document.create_element("a", display_text, "href" => target)
             el.replace(a)
           else
@@ -1292,11 +1249,12 @@ module Metanorma
         doc.traverse do |node|
           next unless node.element?
           next unless %w[xref eref stem link].include?(node.name)
+
           next_sib = node.next_sibling
           while next_sib.is_a?(Nokogiri::XML::Text) && next_sib.text.strip.empty?
             next_sib = next_sib.next_sibling
           end
-          next unless next_sib && next_sib.element? && next_sib.name == "semx"
+          next unless next_sib&.element? && next_sib.name == "semx"
 
           deduplicate_semx_label(node, next_sib)
           node.remove
@@ -1304,6 +1262,10 @@ module Metanorma
         # Strip presentation wrappers, keeping inner content
         %w[semx fmt-xref].each do |tag|
           doc.css(tag).each { |el| el.replace(el.children) }
+        end
+        # Remap XML class names to HTML-specific class names
+        doc.css("[class]").each do |el|
+          el["class"] = el["class"].split(/\s+/).map { |c| html_class_for_span(c) }.join(" ")
         end
         doc.inner_html
       end
@@ -1328,13 +1290,13 @@ module Metanorma
 
       def render_link(link)
         target = safe_attr(link, :target) || safe_attr(link, :href)
-        attrs = element_attrs(href: target, id: safe_attr(link, :id), class: safe_attr(link, :class_attr))
+        attrs = element_attrs(href: target, id: safe_attr(link, :id))
         tag("a", attrs) do
           content = safe_attr(link, :content)
           if content && !Array(content).join.strip.empty?
             render_mixed_inline(link)
           else
-            display_text = target.to_s.sub(/\Amailto:/, "")
+            display_text = target.to_s.delete_prefix("mailto:")
             @output << escape_html(display_text)
           end
         end
@@ -1342,7 +1304,7 @@ module Metanorma
 
       def render_xref(xref)
         target = safe_attr(xref, :target) || safe_attr(xref, :to_attr)
-        attrs = element_attrs(href: "##{escape_html(target)}", id: safe_attr(xref, :id), class: safe_attr(xref, :class_attr))
+        attrs = element_attrs(href: "##{escape_html(target)}", id: safe_attr(xref, :id))
         tag("a", attrs) { render_mixed_inline(xref) }
       end
 
@@ -1460,14 +1422,13 @@ module Metanorma
         attrs.each do |k, v|
           next if v.nil? || v == false || (v.is_a?(String) && v.empty?)
 
-          val = k == :class ? translate_class(v.to_s) : v.to_s
-          parts << %( #{k}="#{escape_html(val)}")
+          parts << %( #{k}="#{escape_html(v.to_s)}")
         end
         parts.join
       end
 
-      def translate_class(class_str)
-        class_str.split(/\s+/).map { |c| CLASS_MAP[c] || c }.join(" ")
+      def html_class_for_span(xml_class)
+        SPAN_ROLE_CLASSES[xml_class] || "span-#{xml_class}"
       end
 
       def block_element?(obj)
@@ -1503,7 +1464,7 @@ module Metanorma
           secondary: safe_attr(element, :secondary)&.to_s&.strip,
           tertiary: safe_attr(element, :tertiary)&.to_s&.strip,
           target_id: @current_section_id,
-          target_text: @current_section_number
+          target_text: @current_section_number,
         )
       rescue StandardError
         nil

--- a/lib/metanorma/html/drops.rb
+++ b/lib/metanorma/html/drops.rb
@@ -4,6 +4,13 @@ module Metanorma
   module Html
     module Drops
       autoload :FootnoteDrop, "metanorma/html/drops/footnote_drop"
+      autoload :BlockElementDrop, "metanorma/html/drops/block_element_drop"
+      autoload :NoteDrop, "metanorma/html/drops/note_drop"
+      autoload :AdmonitionDrop, "metanorma/html/drops/admonition_drop"
+      autoload :ExampleDrop, "metanorma/html/drops/example_drop"
+      autoload :SourcecodeDrop, "metanorma/html/drops/sourcecode_drop"
+      autoload :FormulaDrop, "metanorma/html/drops/formula_drop"
+      autoload :FigureDrop, "metanorma/html/drops/figure_drop"
     end
   end
 end

--- a/lib/metanorma/html/drops/admonition_drop.rb
+++ b/lib/metanorma/html/drops/admonition_drop.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Html
+    module Drops
+      class AdmonitionDrop < BlockElementDrop
+        def self.from_model(admonition, renderer:)
+          type = renderer.safe_attr(admonition, :type) || "note"
+          id = renderer.safe_attr(admonition, :id)
+
+          content_html = renderer.capture_output do
+            admonition.paragraphs&.each { |para| renderer.render_paragraph(para) }
+          end
+
+          new(
+            id: id,
+            type: type,
+            label_html: renderer.escape_html(type.capitalize),
+            content_html: content_html,
+            css_class: "admonition #{type}",
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/html/drops/block_element_drop.rb
+++ b/lib/metanorma/html/drops/block_element_drop.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Html
+    module Drops
+      class BlockElementDrop < Liquid::Drop
+        attr_reader :id, :type, :label_html, :content_html, :css_class
+
+        def initialize(attrs = {})
+          attrs.each { |k, v| instance_variable_set(:"@#{k}", v) }
+        end
+
+        # Subclasses override to build from model + RendererContext
+        def self.from_model(_model, renderer:)
+          raise NotImplementedError, "#{name} must implement .from_model"
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/html/drops/example_drop.rb
+++ b/lib/metanorma/html/drops/example_drop.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Html
+    module Drops
+      class ExampleDrop < BlockElementDrop
+        def self.from_model(example, renderer:)
+          id = renderer.safe_attr(example, :id)
+          label = renderer.extract_block_label(example, "EXAMPLE")
+
+          content_html = renderer.capture_output do
+            if example.paragraphs && !example.paragraphs.empty?
+              example.paragraphs.each { |para| renderer.render_paragraph(para) }
+            end
+            example.ul&.each { |ul| renderer.render_unordered_list(ul) }
+            example.ol&.each { |ol| renderer.render_ordered_list(ol) }
+            example.dl&.each { |dl| renderer.render_definition_list(dl) }
+            example.sourcecode&.each { |sc| renderer.render_sourcecode(sc) }
+            example.table&.each { |t| renderer.render_table(t) }
+            example.figure&.each { |f| renderer.render_figure(f) }
+            example.quote&.each { |q| renderer.render_quote(q) }
+            example.formula&.each { |f| renderer.render_formula(f) }
+          end
+
+          new(
+            id: id,
+            label_html: renderer.escape_html(label),
+            content_html: content_html,
+            css_class: "example",
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/html/drops/figure_drop.rb
+++ b/lib/metanorma/html/drops/figure_drop.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Html
+    module Drops
+      class FigureDrop < BlockElementDrop
+        attr_reader :image_html, :caption_html, :key_html, :sub_figures_html
+
+        def self.from_model(figure, renderer:)
+          id = renderer.safe_attr(figure, :id)
+          fig_name = renderer.safe_attr(figure, :fmt_name) || renderer.safe_attr(figure, :name)
+          if id && fig_name
+            renderer.register_figure_entry(id: id, text: renderer.extract_plain_text(fig_name))
+          end
+
+          image_html = renderer.capture_output do
+            if figure.image
+              renderer.render_image(figure.image)
+            elsif renderer.safe_attr(figure, :source)
+              src = renderer.safe_attr(figure, :source)
+              @output << %(<img src="#{renderer.escape_html(src)}" />)
+            end
+          end
+
+          caption_html = if fig_name || renderer.safe_attr(figure, :name)
+                           renderer.capture_output do
+                             el = renderer.safe_attr(figure, :fmt_name) || figure.name
+                             renderer.render_inline_element(el)
+                           end
+                         end
+
+          sub_figures_html = renderer.capture_output do
+            figure.figure&.each { |sub| renderer.render_figure(sub) }
+          end
+
+          key_html = renderer.capture_output do
+            renderer.safe_attr(figure, :note)&.each { |n| renderer.render_note(n) }
+            renderer.safe_attr(figure, :dl)&.then { |dl| renderer.render_definition_list(dl) }
+          end
+
+          new(
+            id: id,
+            image_html: image_html,
+            caption_html: caption_html,
+            key_html: key_html,
+            sub_figures_html: sub_figures_html,
+            css_class: "figure",
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/html/drops/formula_drop.rb
+++ b/lib/metanorma/html/drops/formula_drop.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Html
+    module Drops
+      class FormulaDrop < BlockElementDrop
+        attr_reader :stem_html, :where_html, :number_html
+
+        def self.from_model(formula, renderer:)
+          id = renderer.safe_attr(formula, :id)
+
+          stem_html = renderer.capture_output do
+            renderer.render_stem_content(formula.stem) if formula.stem
+          end
+
+          where_html = renderer.capture_output do
+            if formula.key
+              if formula.key.dl
+                @output = renderer.capture_output {}
+                # "where" label rendered in template, just render the dl
+                renderer.render_definition_list(formula.key.dl)
+              end
+              formula.key.p&.each { |para| renderer.render_paragraph(para) }
+            end
+            formula.dl&.then { |dl| renderer.render_definition_list(dl) }
+          end
+
+          name_el = renderer.safe_attr(formula, :fmt_name) || renderer.safe_attr(formula, :name)
+          number_html = if name_el
+                          renderer.capture_output { renderer.render_inline_element(name_el) }
+                        end
+
+          new(
+            id: id,
+            stem_html: stem_html,
+            where_html: where_html,
+            number_html: number_html,
+            css_class: "formula",
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/html/drops/note_drop.rb
+++ b/lib/metanorma/html/drops/note_drop.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Html
+    module Drops
+      class NoteDrop < BlockElementDrop
+        def self.from_model(note, renderer:)
+          id = renderer.safe_attr(note, :id)
+          label = renderer.extract_block_label(note, "NOTE")
+
+          content_html = renderer.capture_output do
+            if note.content && !note.content.empty?
+              note.content.each { |para| renderer.render_paragraph(para) }
+            else
+              renderer.render_mixed_inline(note)
+            end
+            note.ul&.each { |ul| renderer.render_unordered_list(ul) }
+            note.ol&.each { |ol| renderer.render_ordered_list(ol) }
+            note.dl&.then { |dl| renderer.render_definition_list(dl) }
+          end
+
+          new(
+            id: id,
+            label_html: renderer.escape_html(label),
+            content_html: content_html,
+            css_class: "note-block",
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/html/drops/sourcecode_drop.rb
+++ b/lib/metanorma/html/drops/sourcecode_drop.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Html
+    module Drops
+      class SourcecodeDrop < BlockElementDrop
+        attr_reader :lang, :name_html, :code_html
+
+        def self.from_model(sc, renderer:)
+          id = renderer.safe_attr(sc, :id)
+          lang = renderer.safe_attr(sc, :lang)
+
+          name_html = if sc.name
+                        renderer.capture_output { renderer.render_inline_element(sc.name) }
+                      end
+
+          code_text = if sc.body&.content
+                        sc.body.content
+                      elsif sc.content
+                        sc.content
+                      else
+                        ""
+                      end
+          raw_text = code_text.gsub("&lt;", "<").gsub("&gt;", ">").gsub("&amp;", "&").gsub("&quot;", "\"")
+
+          new(
+            id: id,
+            lang: lang,
+            name_html: name_html,
+            code_html: renderer.escape_html(raw_text),
+            css_class: "sourcecode",
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/html/iso_renderer.rb
+++ b/lib/metanorma/html/iso_renderer.rb
@@ -67,32 +67,32 @@ module Metanorma
         end
       end
 
-      def render(node, **opts)
+      def render(node, **)
         case node
         when Metanorma::IsoDocument::Root
-          render_document(node, **opts)
+          render_document(node, **)
         when Metanorma::IsoDocument::Sections::IsoPreface
-          render_preface(node, **opts)
+          render_preface(node, **)
         when Metanorma::IsoDocument::Sections::IsoSections
-          render_sections(node, **opts)
+          render_sections(node, **)
         when Metanorma::IsoDocument::Sections::IsoClauseSection
-          render_clause(node, **opts)
+          render_clause(node, **)
         when Metanorma::IsoDocument::Sections::IsoAnnexSection
-          render_annex(node, **opts)
+          render_annex(node, **)
         when Metanorma::IsoDocument::Sections::IsoTermsSection
-          render_terms_section(node, **opts)
+          render_terms_section(node, **)
         when Metanorma::IsoDocument::Sections::IsoForewordSection
-          render_foreword(node, **opts)
+          render_foreword(node, **)
         when Metanorma::IsoDocument::Sections::IsoAbstractSection
-          render_abstract(node, **opts)
+          render_abstract(node, **)
         when Metanorma::IsoDocument::Terms::IsoTerm
-          render_term(node, **opts)
+          render_term(node, **)
         when Metanorma::IsoDocument::Terms::TermNote
-          render_term_note(node, **opts)
+          render_term_note(node, **)
         when Metanorma::IsoDocument::Terms::TermExample
-          render_term_example(node, **opts)
+          render_term_example(node, **)
         when Metanorma::IsoDocument::Boilerplate
-          render_boilerplate(node, **opts)
+          render_boilerplate(node, **)
         else
           super
         end
@@ -147,33 +147,35 @@ module Metanorma
 
       # Extract English stage text, deduplicating duplicate language variants.
       def extract_stage(bibdata)
-        return nil unless bibdata.status && bibdata.status.stage
+        return nil unless bibdata.status&.stage
 
         stages = Array(bibdata.status.stage)
         return nil if stages.empty?
 
         # Prefer English-language stage
-        en_stage = stages.find { |s|
+        en_stage = stages.find do |s|
           lang = safe_attr(s, :language)
           lang == "en" if lang
-        }
-        return Array(en_stage.value).join.strip if en_stage && en_stage.value
+        end
+        return Array(en_stage.value).join.strip if en_stage&.value
 
         # Fallback: first non-empty, deduplicated
         seen = Set.new
-        stage_text = stages.filter_map { |s|
+        stage_text = stages.filter_map do |s|
           val = Array(s.value).join.strip
           down = val.downcase
           next if seen.include?(down)
+
           seen << down
           val.empty? ? nil : val
-        }.compact.join(" ")
+        end.compact.join(" ")
         stage_text.empty? ? nil : stage_text
       end
 
       # Extract document type from ext.doctype.
       def extract_doctype(bibdata)
         return nil unless bibdata.respond_to?(:ext)
+
         ext = bibdata.ext
         return nil unless ext
 
@@ -181,11 +183,11 @@ module Metanorma
         return nil unless doctypes && !doctypes.empty?
 
         # Prefer English-language doctype
-        en_dt = doctypes.find { |d|
+        en_dt = doctypes.find do |d|
           lang = safe_attr(d, :language)
           lang == "en" if lang
-        }
-        return en_dt.value.to_s if en_dt && en_dt.value
+        end
+        return en_dt.value.to_s if en_dt&.value
 
         # Fallback: first doctype
         dt = doctypes.first
@@ -216,7 +218,7 @@ module Metanorma
         all_items.each do |node|
           next if node.is_a?(String)
           next if is_title_element?(node, doc.sections)
-          next if is_doc_title_paragraph?(node)
+
           render(node)
         end
 
@@ -254,13 +256,13 @@ module Metanorma
         stage_text = extract_stage(bibdata)
 
         @output << render_liquid("_iso_cover.html.liquid", {
-          "publisher_logos" => logos,
-          "doc_id" => doc_id,
-          "pub_date" => pub_date,
-          "doctype" => doctype,
-          "title" => title_text,
-          "stage" => stage_text,
-        })
+                                   "publisher_logos" => logos,
+                                   "doc_id" => doc_id,
+                                   "pub_date" => pub_date,
+                                   "doctype" => doctype,
+                                   "title" => title_text,
+                                   "stage" => stage_text,
+                                 })
       end
 
       def render_doc_title(doc)
@@ -274,8 +276,8 @@ module Metanorma
         return unless en_title
 
         @output << render_liquid("_iso_doc_title.html.liquid", {
-          "title" => en_title.to_s,
-        })
+                                   "title" => en_title.to_s,
+                                 })
       end
 
       def render_boilerplate_section(doc)
@@ -303,7 +305,7 @@ module Metanorma
             fw_id = safe_attr(fw, :id)
             title_text = extract_plain_text(title)
             register_toc_entry(id: fw_id, level: level, text: title_text)
-            @output << "<h1 class=\"ForewordTitle\">"
+            @output << "<h1 class=\"foreword-title\">"
             render_mixed_inline(title)
             @output << "</h1>"
           end
@@ -319,7 +321,7 @@ module Metanorma
             sec_id = safe_attr(section, :id)
             title_text = extract_plain_text(title)
             register_toc_entry(id: sec_id, level: level, text: title_text)
-            @output << "<h1 class=\"IntroTitle\">"
+            @output << "<h1 class=\"intro-title\">"
             render_mixed_inline(title)
             @output << "</h1>"
           end
@@ -344,7 +346,7 @@ module Metanorma
       # --- Clause rendering ---
 
       def render_clause(clause, level: 1, **_opts)
-        attrs = element_attrs(id: safe_attr(clause, :id), class: safe_attr(clause, :class_attr))
+        attrs = element_attrs(id: safe_attr(clause, :id))
         tag("div", attrs) do
           render_title(clause, level)
           render_ordered_content(clause, level)
@@ -354,7 +356,7 @@ module Metanorma
       # --- Annex rendering ---
 
       def render_annex(annex, level: 1, **_opts)
-        attrs = element_attrs(id: safe_attr(annex, :id), class: "Section3")
+        attrs = element_attrs(id: safe_attr(annex, :id), class: "section-sub")
         tag("div", attrs) do
           render_annex_title(annex, level)
           render_ordered_content(annex, level)
@@ -370,7 +372,7 @@ module Metanorma
         register_toc_entry(id: annex_id, level: level, text: title_text)
 
         h = "h#{[[level, 6].min, 1].max}"
-        @output << "<#{h} class=\"Annex\">"
+        @output << "<#{h} class=\"annex-title\">"
         render_mixed_inline(title_element)
         @output << "</#{h}>"
       end
@@ -398,7 +400,7 @@ module Metanorma
           # In presentation mode, use fmt_* elements
           if term.fmt_name
             # Render term number (e.g. "3.1")
-            @output << "<p class=\"TermNum\">"
+            @output << "<p class=\"term-number\">"
             render_inline_element(term.fmt_name)
             @output << "</p>"
           elsif term.term_number
@@ -408,7 +410,7 @@ module Metanorma
                       else
                         extract_text_value(tn)
                       end
-            @output << "<p class=\"TermNum\">#{escape_html(tn_text)}</p>"
+            @output << "<p class=\"term-number\">#{escape_html(tn_text)}</p>"
           end
 
           # Preferred designations — use fmt-preferred if available
@@ -436,7 +438,7 @@ module Metanorma
           # (fmt-definition already includes domain text in its content)
           if term.domain && !term.fmt_definition
             domain_text = safe_attr(term.domain, :text)
-            @output << "<p class=\"domain\">&lt;#{escape_html(domain_text)}&gt;</p>" if domain_text
+            @output << "<p class=\"term-domain\">&lt;#{escape_html(domain_text)}&gt;</p>" if domain_text
           end
 
           # Definition — use fmt-definition if available
@@ -458,7 +460,7 @@ module Metanorma
           # Source references — use fmt-termsource if available
           if term.fmt_termsource && !term.fmt_termsource.empty?
             term.fmt_termsource.each do |fts|
-              @output << "<p class=\"source\">"
+              @output << "<p class=\"term-source\">"
               render_mixed_inline(fts)
               @output << "</p>"
             end
@@ -485,7 +487,8 @@ module Metanorma
         if term.preferred && !term.preferred.empty?
           return extract_designation_name(term.preferred.first).to_s
         end
-        safe_attr(term, :id).to_s.sub(/\Aterm-/, "")
+
+        safe_attr(term, :id).to_s.delete_prefix("term-")
       end
 
       def extract_term_definition(term)
@@ -502,11 +505,11 @@ module Metanorma
 
       def strip_html(html)
         html.gsub(/<[^>]+>/, "").gsub("&lt;", "<").gsub("&gt;", ">")
-            .gsub("&amp;", "&").gsub("&nbsp;", " ")
+          .gsub("&amp;", "&").gsub("&nbsp;", " ")
       end
 
       def render_term_designation(designation, type)
-        css_class = type == "deprecated" ? "DeprecatedTerms" : "Terms"
+        css_class = type == "deprecated" ? "term-deprecated" : "term-name"
         @output << "<p class=\"#{css_class}\" style=\"text-align:left;\">"
         @output << "<del>" if type == "deprecated"
         @output << "<b><dfn>"
@@ -583,10 +586,10 @@ module Metanorma
       end
 
       def render_term_note(note)
-        attrs = element_attrs(id: safe_attr(note, :id), class: "Note")
+        attrs = element_attrs(id: safe_attr(note, :id), class: "note-block")
         tag("div", attrs) do
           label = extract_termnote_label(note)
-          @output << "<p><span class=\"termnote_label\">#{escape_html(label)}: </span>"
+          @output << "<p><span class=\"term-note-label\">#{escape_html(label)}: </span>"
           note.p&.each { |para| render_mixed_inline(para) }
           @output << "</p>"
           note.ul&.each { |ul| render_unordered_list(ul) }
@@ -599,7 +602,7 @@ module Metanorma
         attrs = element_attrs(id: safe_attr(example, :id), class: "example")
         tag("div", attrs) do
           label = extract_block_label(example, "EXAMPLE")
-          @output << "<p><span class=\"example_label\">#{escape_html(label)}</span>&nbsp;"
+          @output << "<p><span class=\"example-label\">#{escape_html(label)}</span>&nbsp;"
           example.p&.each { |para| render_mixed_inline(para) }
           @output << "</p>"
           example.ul&.each { |ul| render_unordered_list(ul) }
@@ -627,7 +630,13 @@ module Metanorma
           .gsub(/<variant-title[^>]*>.*?<\/variant-title>/m, "")
           .gsub(/<\/?(?:copyright-statement|clause)[^>]*>/, "")
 
-        @output << clean.strip
+        # Remap XML class names to HTML-specific class names
+        boilerplate_doc = Nokogiri::HTML::DocumentFragment.parse(clean)
+        boilerplate_doc.css("[class]").each do |el|
+          el["class"] = el["class"].split(/\s+/).map { |c| html_class_for_span(c) }.join(" ")
+        end
+
+        @output << boilerplate_doc.inner_html.strip
 
         @output << "</div>"
       end
@@ -641,19 +650,19 @@ module Metanorma
             next_sib = next_sib.next_sibling
           end
 
-          display_text = if next_sib && next_sib.element? && next_sib.name == "semx"
-            fmt_link = next_sib.at_css("fmt-link")
-            if fmt_link
-              fmt_target = fmt_link["target"] || fmt_link["href"] || target
-              display_text = fmt_target.to_s.sub(/\Amailto:/, "")
-              next_sib.remove
-              display_text
-            end
-          end
+          display_text = if next_sib&.element? && next_sib.name == "semx"
+                           fmt_link = next_sib.at_css("fmt-link")
+                           if fmt_link
+                             fmt_target = fmt_link["target"] || fmt_link["href"] || target
+                             display_text = fmt_target.to_s.delete_prefix("mailto:")
+                             next_sib.remove
+                             display_text
+                           end
+                         end
 
-          display_text ||= target.to_s.sub(/\Amailto:/, "")
+          display_text ||= target.to_s.delete_prefix("mailto:")
           a_tag = Nokogiri::HTML::DocumentFragment.parse(
-            "<a href=\"#{CGI.escapeHTML(target.to_s)}\">#{CGI.escapeHTML(display_text)}</a>"
+            "<a href=\"#{CGI.escapeHTML(target.to_s)}\">#{CGI.escapeHTML(display_text)}</a>",
           )
           link.replace(a_tag)
         end
@@ -686,15 +695,20 @@ module Metanorma
         %i[terms definitions].each do |attr|
           val = safe_attr(section, attr)
           next if val.nil?
+
           Array(val).each do |v|
             children << v unless children.include?(v)
           end
         end
 
         # Sort by displayorder (non-nil first, then nil at end)
-        children.reject!(&:nil?)
+        children.compact!
         children.sort_by do |node|
-          order = node.displayorder rescue nil
+          order = begin
+            node.displayorder
+          rescue StandardError
+            nil
+          end
           order &&= order.to_i
           order || Float::INFINITY
         end
@@ -710,46 +724,49 @@ module Metanorma
         end
       end
 
-      private
-
-      # Filter document title paragraphs that are rendered by render_doc_title
-      def is_doc_title_paragraph?(node)
-        return false unless node.respond_to?(:class_attr)
-        ["zzSTDTitle1", "zzSTDTitle2"].include?(node.class_attr)
-      end
-
       # Collect all document-level children (sections, normative refs, annexes,
       # bibliography) sorted by displayorder for correct document order.
+      # Top-level paragraphs in sections (title paragraphs) are excluded —
+      # they are rendered separately by render_doc_title.
       def collect_document_children(doc)
         items = []
 
         # Main sections children (clauses, terms, etc.)
         if doc.sections
-          items.concat(gather_element_order_children(doc.sections))
+          section_children = gather_element_order_children(doc.sections)
+          # Title paragraphs are ParagraphBlock objects at the top level of
+          # sections. They are rendered by render_doc_title, so skip them here.
+          section_children.reject! do |node|
+            node.is_a?(Metanorma::Document::Components::Paragraphs::ParagraphBlock)
+          end
+          items.concat(section_children)
           # Also add typed attributes that may not be in element_order
           %i[terms definitions].each do |attr|
             val = safe_attr(doc.sections, attr)
             next if val.nil?
+
             Array(val).each { |v| items << v unless items.include?(v) }
           end
         end
 
         # Normative references from bibliography (may have displayorder)
-        if doc.bibliography && doc.bibliography.references
-          doc.bibliography.references.each { |r| items << r }
-        end
+        doc.bibliography&.references&.each { |r| items << r }
 
         # Annexes
         doc.annex&.each { |a| items << a }
 
         # Non-normative bibliography (no displayorder = goes at end)
-        if doc.bibliography && doc.bibliography.references
+        if doc.bibliography&.references
           # Already included above; filter normative vs non-normative below
         end
 
         items.compact!
         items.sort_by do |node|
-          order = node.displayorder rescue nil
+          order = begin
+            node.displayorder
+          rescue StandardError
+            nil
+          end
           order &&= order.to_i
           order || Float::INFINITY
         end
@@ -797,7 +814,7 @@ module Metanorma
         children
       end
 
-      def publisher_logos_html(doc)
+      def publisher_logos_html(_doc)
         publishers = flavor_publishers(extract_primary_doc_id)
         logo_map = publisher_logo_map
         return [] if publishers.empty? && logo_map.empty?
@@ -811,8 +828,8 @@ module Metanorma
           next unless svg
 
           # White fill for dark cover background
-          svg = svg.gsub(/fill:#00b1ff/, "fill:white") if pub == "OGC"
-          svg = svg.gsub(/fill:#e3000f/, "fill:white") if pub == "ISO"
+          svg = svg.gsub("fill:#00b1ff", "fill:white") if pub == "OGC"
+          svg = svg.gsub("fill:#e3000f", "fill:white") if pub == "ISO"
           svg
         end
       end

--- a/lib/metanorma/html/ogc_renderer.rb
+++ b/lib/metanorma/html/ogc_renderer.rb
@@ -46,7 +46,7 @@ module Metanorma
           t.example_bg      = "#e8f4fa"
           t.example_color   = "#004d73"
           t.admonition_border = "#e8812e"
-          t.admonition_bg   = "#fff5eb"
+          t.admonition_bg = "#fff5eb"
           t.admonition_color = "#c06a1a"
           t.footer_border_color = "#00b1ff"
           t.cover_separator_color = "rgba(0,177,255,0.25)"
@@ -69,13 +69,13 @@ module Metanorma
         preface_clauses = preface.clause&.reject { |cl| cl.type == "toc" } || []
 
         return if preface_clauses.empty? &&
-                  !preface.foreword && !preface.introduction &&
-                  !preface.abstract && !preface.acknowledgements &&
-                  !preface.executivesummary
+          !preface.foreword && !preface.introduction &&
+          !preface.abstract && !preface.acknowledgements &&
+          !preface.executivesummary
 
         @output << "<div id=\"preface\" class=\"preface-section\">"
         register_toc_entry(id: "preface", level: 1, text: "Preface")
-        @output << "<h1 class=\"ForewordTitle\">Preface</h1>"
+        @output << "<h1 class=\"foreword-title\">Preface</h1>"
 
         preface_clauses.each { |cl| render(cl, level: 2) }
 

--- a/lib/metanorma/html/standard_renderer.rb
+++ b/lib/metanorma/html/standard_renderer.rb
@@ -5,34 +5,34 @@ module Metanorma
     # Renders StandardDocument components to HTML.
     # Extends BaseRenderer with terms, bibliography, and standard sections.
     class StandardRenderer < BaseRenderer
-      def render(node, **opts)
+      def render(node, **)
         case node
         when Metanorma::StandardDocument::Root
-          render_standard_document(node, **opts)
+          render_standard_document(node, **)
         when Metanorma::StandardDocument::Terms::Term
-          render_term(node, **opts)
+          render_term(node, **)
         when Metanorma::StandardDocument::Sections::TermsSection
-          render_terms_section(node, **opts)
+          render_terms_section(node, **)
         when Metanorma::StandardDocument::Sections::StandardReferencesSection
-          render_references_section(node, **opts)
+          render_references_section(node, **)
         when Metanorma::StandardDocument::Sections::BibliographySection
-          render_bibliography(node, **opts)
+          render_bibliography(node, **)
         when Metanorma::StandardDocument::Sections::ClauseSection
-          render_clause_section(node, **opts)
+          render_clause_section(node, **)
         when Metanorma::StandardDocument::Sections::AnnexSection
-          render_annex_section(node, **opts)
+          render_annex_section(node, **)
         when Metanorma::StandardDocument::Sections::StandardSection
-          render_standard_section(node, **opts)
+          render_standard_section(node, **)
         when Metanorma::StandardDocument::Sections::Abstract
-          render_abstract_section(node, **opts)
+          render_abstract_section(node, **)
         when Metanorma::StandardDocument::Sections::Foreword
-          render_foreword_section(node, **opts)
+          render_foreword_section(node, **)
         when Metanorma::StandardDocument::Sections::Introduction
-          render_introduction_section(node, **opts)
+          render_introduction_section(node, **)
         when Metanorma::StandardDocument::Sections::FloatingTitle
-          render_floating_title(node, **opts)
+          render_floating_title(node, **)
         when Metanorma::StandardDocument::Blocks::AmendBlock
-          render_amend_block(node, **opts)
+          render_amend_block(node, **)
         else
           super
         end
@@ -86,8 +86,10 @@ module Metanorma
         cover_id = nil
         bibdata.doc_identifier&.each do |di|
           next unless safe_attr(di, :type) == "iso-reference"
+
           id = extract_text_value(di)
           next if id.to_s.empty?
+
           cover_id = id
           break
         end
@@ -105,9 +107,9 @@ module Metanorma
         end
 
         @output << render_liquid("_cover.html.liquid", {
-          "doc_id" => cover_id,
-          "title" => title_text,
-        })
+                                   "doc_id" => cover_id,
+                                   "title" => title_text,
+                                 })
       end
 
       def render_doc_title(doc)
@@ -120,22 +122,24 @@ module Metanorma
         elsif bibdata.is_a?(Metanorma::Document::Components::BibData::BibData)
           titles = bibdata.title
           return unless titles && !titles.empty?
+
           en_title = titles.find { |t| t.language == "en" }
           return unless en_title
+
           en_title = extract_text_value(en_title)
         else
           return
         end
 
         @output << render_liquid("_doc_title.html.liquid", {
-          "title" => en_title,
-        })
+                                   "title" => en_title,
+                                 })
       end
 
       # --- Section rendering ---
 
       def render_clause_section(clause, level: 1, **_opts)
-        attrs = element_attrs(id: safe_attr(clause, :id), class: safe_attr(clause, :class_attr))
+        attrs = element_attrs(id: safe_attr(clause, :id))
         tag("div", attrs) do
           render_standard_title(clause, level)
           render_standard_section_blocks(clause, level)
@@ -324,11 +328,11 @@ module Metanorma
           bibitemid = safe_attr(origin, :bibitemid)
 
           if citeas && !citeas.to_s.empty?
-            if bibitemid && !bibitemid.to_s.empty?
-              @output << "<a href=\"##{escape_html(bibitemid.to_s)}\" class=\"bibref\">#{escape_html(citeas.to_s)}</a>"
-            else
-              @output << escape_html(citeas.to_s)
-            end
+            @output << if bibitemid && !bibitemid.to_s.empty?
+                         "<a href=\"##{escape_html(bibitemid.to_s)}\" class=\"bibref\">#{escape_html(citeas.to_s)}</a>"
+                       else
+                         escape_html(citeas.to_s)
+                       end
           else
             render_mixed_inline(origin)
           end
@@ -401,9 +405,11 @@ module Metanorma
       def bibitem_url(item)
         links = Array(item.link)
         return nil if links.empty?
+
         # Prefer src or citation type, skip RSS feeds
-        preferred = links.find { |l| l.type == "src" || l.type == "citation" }
+        preferred = links.find { |l| ["src", "citation"].include?(l.type) }
         return preferred.content.to_s if preferred && !preferred.content.to_s.empty?
+
         # Fallback: first non-RSS link
         non_rss = links.find { |l| !l.content.to_s.include?(".rss") && !l.content.to_s.empty? }
         non_rss&.content&.to_s
@@ -421,10 +427,10 @@ module Metanorma
           docids = Array(item.docidentifier)
           # Skip bracket-number identifiers (e.g. "[1]") and iso-reference/URN variants;
           # render only the primary doc identifier
-          primary = docids.find { |di|
+          primary = docids.find do |di|
             val = extract_text_value(di).to_s
             val.match?(/\A\[?\d+\]?\z/) ? false : !val.match?(/\A(?:iso-reference|URN)\s/)
-          }
+          end
           if primary
             id_val = extract_text_value(primary)
             @output << "<span class=\"std-doc-number\">#{escape_html(id_val)}</span>" unless id_val.to_s.empty?

--- a/lib/metanorma/html/templates/_admonition.html.liquid
+++ b/lib/metanorma/html/templates/_admonition.html.liquid
@@ -1,0 +1,4 @@
+<div{% if block.id %} id="{{ block.id }}"{% endif %} class="{{ block.css_class }}">
+<p class="admonition-title">{{ block.label_html }}</p>
+{{ block.content_html }}
+</div>

--- a/lib/metanorma/html/templates/_doc_title.html.liquid
+++ b/lib/metanorma/html/templates/_doc_title.html.liquid
@@ -1,3 +1,3 @@
 <p class="doc-title">
-  <span class="bold-title">{{ title | escape }}</span>
+  <span class="title-text">{{ title | escape }}</span>
 </p>

--- a/lib/metanorma/html/templates/_example.html.liquid
+++ b/lib/metanorma/html/templates/_example.html.liquid
@@ -1,0 +1,3 @@
+<div{% if block.id %} id="{{ block.id }}"{% endif %} class="{{ block.css_class }}">
+<span class="example-label">{{ block.label_html }}</span>&nbsp;{{ block.content_html }}
+</div>

--- a/lib/metanorma/html/templates/_figure.html.liquid
+++ b/lib/metanorma/html/templates/_figure.html.liquid
@@ -1,0 +1,6 @@
+<figure{% if block.id %} id="{{ block.id }}"{% endif %} class="{{ block.css_class }}">
+{{ block.image_html }}
+{{ block.sub_figures_html }}
+{% if block.caption_html %}<figcaption>{{ block.caption_html }}</figcaption>{% endif %}
+{{ block.key_html }}
+</figure>

--- a/lib/metanorma/html/templates/_formula.html.liquid
+++ b/lib/metanorma/html/templates/_formula.html.liquid
@@ -1,0 +1,6 @@
+<div{% if block.id %} id="{{ block.id }}"{% endif %} class="{{ block.css_class }}">
+{{ block.stem_html }}
+{% if block.where_html %}<p class="formula-where">where</p>{% endif %}
+{{ block.where_html }}
+{% if block.number_html %}<span class="formula-number">{{ block.number_html }}</span>{% endif %}
+</div>

--- a/lib/metanorma/html/templates/_iso_doc_title.html.liquid
+++ b/lib/metanorma/html/templates/_iso_doc_title.html.liquid
@@ -1,3 +1,3 @@
-<p class="zzSTDTitle1">
-<span class="boldtitle">{{ title | escape }}</span>
+<p class="doc-title">
+<span class="title-text">{{ title | escape }}</span>
 </p>

--- a/lib/metanorma/html/templates/_note.html.liquid
+++ b/lib/metanorma/html/templates/_note.html.liquid
@@ -1,0 +1,3 @@
+<div{% if block.id %} id="{{ block.id }}"{% endif %} class="{{ block.css_class }}">
+<span class="note-label">{{ block.label_html }}</span>&nbsp;{{ block.content_html }}
+</div>

--- a/lib/metanorma/html/templates/_sourcecode.html.liquid
+++ b/lib/metanorma/html/templates/_sourcecode.html.liquid
@@ -1,0 +1,4 @@
+<div{% if block.id %} id="{{ block.id }}"{% endif %} class="{{ block.css_class }}">
+{% if block.name_html %}<p class="code-name">{{ block.name_html }}</p>{% endif %}
+<pre><code{% if block.lang %} lang="{{ block.lang }}"{% endif %}>{{ block.code_html }}</code></pre>
+</div>

--- a/spec/metanorma/html/generator_spec.rb
+++ b/spec/metanorma/html/generator_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "metanorma/html/generator"
+
+RSpec.describe Metanorma::Html::Generator do
+  let(:xml_path) { File.expand_path("../../fixtures/iso/is/document-en.presentation.xml", __dir__) }
+  let(:xml) { File.read(xml_path) }
+  let(:doc) { Metanorma::IsoDocument::Root.from_xml(xml) }
+  let(:html) { described_class.generate(doc) }
+  let(:page) { Nokogiri::HTML(html) }
+
+  describe "document title" do
+    it "renders the document title without Liquid errors" do
+      html.should_not include("Liquid error")
+    end
+
+    it "renders the title in a doc-title container" do
+      title_el = page.at_css(".doc-title")
+      title_el.should_not be_nil
+      title_el.text.should include("Cereals and pulses")
+    end
+  end
+
+  describe "copyright boilerplate" do
+    it "renders the email address as a link" do
+      link = page.at_css('a[href="mailto:copyright@iso.org"]')
+      link.should_not be_nil
+      link.text.should eq("copyright@iso.org")
+    end
+
+    it "renders Published in Switzerland" do
+      page.at_css("#boilerplate-place").text.should include("Published in Switzerland")
+    end
+  end
+
+  describe "terms and definitions" do
+    it "renders term numbers" do
+      term_nums = page.css(".term-number")
+      term_nums.length.should be > 0
+      term_nums.first.text.should include("3")
+    end
+
+    it "renders DEPRECATED label" do
+      deprecated_text = page.css("p").map(&:inner_text).find { |t| t.include?("DEPRECATED") }
+      deprecated_text.should_not be_nil
+    end
+
+    it "does not duplicate domain text in term 3.6" do
+      term_el = page.at_css('[id="term-_rice_-extraneous-matter"]')
+      term_el.should_not be_nil
+      paragraphs = term_el.css("p").map(&:inner_text)
+      rice_paragraphs = paragraphs.select { |t| t.include?("<rice>") }
+      rice_paragraphs.length.should eq(1)
+    end
+  end
+
+  describe "bibliography cross-references" do
+    it "does not double the Reference label" do
+      page.css("h2, h3").map(&:text).none? { |t| t.match?(/Reference.*Reference/) }.should be(true)
+    end
+  end
+
+  describe "footnotes" do
+    it "renders footnotes section" do
+      page.at_css(".footnotes-section").should_not be_nil
+    end
+
+    it "renders footnote back-references" do
+      page.at_css(".footnote-backref").should_not be_nil
+    end
+  end
+
+  describe "mailto links" do
+    it "strips mailto: prefix from display text" do
+      link = page.at_css('a[href="mailto:gehf@vacheequipment.fic"]')
+      link.should_not be_nil
+      link.text.should eq("gehf@vacheequipment.fic")
+    end
+  end
+
+  describe "block elements" do
+    it "renders notes with note-block class" do
+      page.at_css(".note-block").should_not be_nil
+    end
+
+    it "renders examples" do
+      page.at_css(".example").should_not be_nil
+    end
+
+    it "renders figures" do
+      page.at_css("figure").should_not be_nil
+    end
+
+    it "renders formulas" do
+      page.at_css(".formula").should_not be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- **Drop pattern**: Introduce `BlockElementDrop` and 6 concrete Drop subclasses (note, example, sourcecode, formula, figure, admonition) with Liquid template rendering, replacing inline HTML string building
- **Class name ownership**: Eliminate all XML-originated class names (`zzSTDTitle1`, `ForewordTitle`, `TermNum`, `DeprecatedTerms`, etc.) from HTML output. Add `SPAN_ROLE_CLASSES` mapping XML roles to HTML-specific names. Add Nokogiri post-processing for boilerplate class remapping
- **Nokogiri tests**: Replace regex-based HTML assertions with proper Nokogiri DOM queries in `generator_spec.rb`
- **Documentation**: Updated `README.adoc` and added `docs/html-renderer.adoc` with full architecture reference

## Commits

1. `00e2bdc` feat: introduce Drop pattern for block elements with Liquid templates
2. `914ac5f` fix: eliminate all XML-originated class names from HTML output
3. `cb65edd` test: add Nokogiri-based HTML generator tests
4. `2620583` docs: update README and add HTML renderer architecture docs

## Test plan

- [x] All 15 generator specs pass with Nokogiri assertions
- [x] No XML-originated class names in HTML output (verified via audit script)
- [x] All 68 roundtrip tests still pass