### PR TITLE
feat(html): TermNum heading markup, note/example labels inside first p

### DIFF
--- a/data/stylesheets/base/_dark.css
+++ b/data/stylesheets/base/_dark.css
@@ -37,7 +37,7 @@
 [data-theme="dark"] .code-copy-btn { background: rgba(255,255,255,0.06); border-color: rgba(255,255,255,0.1); }
 [data-theme="dark"] .table-scroll-wrapper { box-shadow: 0 1px 3px rgba(0,0,0,0.3); }
 [data-theme="dark"] .caption-label, [data-theme="dark"] .fmt-caption-label { color: #a8b4e0; }
-[data-theme="dark"] .term-number { color: #a8b4e0; }
+[data-theme="dark"] .TermNum { color: #a8b4e0; }
 [data-theme="dark"] .term-name { color: var(--color-text); }
 [data-theme="dark"] div[id^="term-"] { border-top-color: #4a5a9a; }
 [data-theme="dark"] .term-source { border-top-color: var(--color-border); }
@@ -100,7 +100,7 @@
 [data-theme="sepia"] .cover-stage p { border-color: rgba(255,255,255,0.2); }
 [data-theme="sepia"] .code-copy-btn { background: rgba(0,0,0,0.15); border-color: rgba(255,255,255,0.1); }
 [data-theme="sepia"] .caption-label, [data-theme="sepia"] .fmt-caption-label { color: #6b4423; }
-[data-theme="sepia"] .term-number { color: #6b4423; }
+[data-theme="sepia"] .TermNum { color: #6b4423; }
 [data-theme="sepia"] .term-name { color: #6b4423; }
 [data-theme="sepia"] div[id^="term-"] { border-top-color: #a67c20; }
 [data-theme="sepia"] h1 { border-bottom-color: var(--color-border); }
@@ -159,7 +159,7 @@
 [data-theme="oled"] .cover-stage p { border-color: #222; }
 [data-theme="oled"] .code-copy-btn { background: rgba(255,255,255,0.04); border-color: #1a1a1a; }
 [data-theme="oled"] .caption-label, [data-theme="oled"] .fmt-caption-label { color: #c0c0c0; }
-[data-theme="oled"] .term-number { color: #c0c0c0; }
+[data-theme="oled"] .TermNum { color: #c0c0c0; }
 [data-theme="oled"] .term-name { color: #d0d0d0; }
 [data-theme="oled"] div[id^="term-"] { border-top-color: #222; }
 [data-theme="oled"] h1 { border-bottom-color: #1a1a1a; }

--- a/data/stylesheets/base/_print.css
+++ b/data/stylesheets/base/_print.css
@@ -26,7 +26,7 @@
   h1, h2, h3, h4, h5, h6 { page-break-after: avoid; break-after: avoid; }
   .note-block, .example, .admonition, .formula, figure, table { page-break-inside: avoid; break-inside: avoid; }
   .caption-label, .fmt-caption-label { color: #000; padding: 0; }
-  .term-number { color: #000; padding: 0; }
+  .TermNum { color: #000; padding: 0; }
   div[id^="term-"] { border-top: 2px solid #666; background: none; box-shadow: none; }
   .formula-number { background: none; border: none; color: #000; padding: 0; }
   .doc-title::after { display: none; }

--- a/data/stylesheets/components/term.css
+++ b/data/stylesheets/components/term.css
@@ -9,13 +9,15 @@ div[id^="term-"] {
 }
 div[id^="term-"] + div[id^="term-"] { margin-top: 0; }
 
-.term-number {
+/* TermNum is a heading (h2/h3 by nesting depth, per isodoc term_header) */
+.TermNum {
   font-variant: small-caps;
   font-weight: 600;
   color: var(--mn-primary);
   background: none;
   padding: 0;
-  font-size: 0.88em;
+  margin: 0 0 0.4em;
+  font-size: 0.95em;
 }
 .term-name { font-size: 1.1em; color: var(--mn-primary); font-weight: 500; }
 .term-name dfn { font-style: normal; }

--- a/lib/metanorma/html/drops/example_drop.rb
+++ b/lib/metanorma/html/drops/example_drop.rb
@@ -9,6 +9,10 @@ module Metanorma
           label = renderer.extract_block_label(example, "EXAMPLE")
 
           content_html = renderer.render_full_block_children(example) || ""
+          # Same convention as notes: the EXAMPLE label opens the first
+          # paragraph rather than floating outside it.
+          label_html = %(<span class="example-label">#{renderer.escape_html(label)}</span>&nbsp;)
+          content_html = NoteDrop.inject_label(content_html, label_html)
 
           new(
             id: id,

--- a/lib/metanorma/html/drops/note_drop.rb
+++ b/lib/metanorma/html/drops/note_drop.rb
@@ -36,12 +36,31 @@ module Metanorma
         # Inserts the label markup right after the first <p> opening
         # tag; when the note has no paragraph, the label leads the
         # content instead.
+        #
+        # Uses linear string scanning rather than a regex so that
+        # adversarial or malformed input (e.g. an unterminated `<p `
+        # sequence) cannot trigger polynomial backtracking.
         def self.inject_label(content_html, label_html)
-          if content_html.match?(/<p(?:\s[^>]*)?>/)
-            content_html.sub(/<p(?:\s[^>]*)?>/, "\\0#{label_html}")
-          else
-            label_html + content_html
-          end
+          injection_point = first_paragraph_open_tag_end(content_html)
+          return label_html + content_html if injection_point.nil?
+
+          content_html.dup.insert(injection_point, label_html)
+        end
+
+        # Returns the index immediately AFTER the '>' that closes the
+        # first `<p ...>` opening tag in +content_html+, or nil if the
+        # string has no `<p` token. Search is linear: find the first
+        # occurrence of "<p" (optionally followed by attributes up to
+        # the next '>').
+        def self.first_paragraph_open_tag_end(content_html)
+          p_start = content_html.index("<p")
+          return nil if p_start.nil?
+          return nil if p_start + 2 >= content_html.length
+
+          tag_end = content_html.index(">", p_start + 2)
+          return nil if tag_end.nil?
+
+          tag_end + 1
         end
       end
     end

--- a/lib/metanorma/html/drops/note_drop.rb
+++ b/lib/metanorma/html/drops/note_drop.rb
@@ -19,6 +19,11 @@ module Metanorma
           end
           content_parts << (renderer.render_note_children(note) || "")
           content_html = content_parts.join
+          # isodoc convention: the NOTE label opens the first paragraph
+          # (<p><span class="note-label">NOTE</span> text…</p>), it does
+          # not float outside it.
+          label_html = %(<span class="note-label">#{renderer.escape_html(label)}</span>&nbsp;)
+          content_html = inject_label(content_html, label_html)
 
           new(
             id: id,
@@ -26,6 +31,17 @@ module Metanorma
             content_html: content_html,
             css_class: "note-block",
           )
+        end
+
+        # Inserts the label markup right after the first <p> opening
+        # tag; when the note has no paragraph, the label leads the
+        # content instead.
+        def self.inject_label(content_html, label_html)
+          if content_html.match?(/<p(?:\s[^>]*)?>/)
+            content_html.sub(/<p(?:\s[^>]*)?>/, "\\0#{label_html}")
+          else
+            label_html + content_html
+          end
         end
       end
     end

--- a/lib/metanorma/html/standard_renderer.rb
+++ b/lib/metanorma/html/standard_renderer.rb
@@ -100,7 +100,7 @@ module Metanorma
         parts << (render_standard_section_blocks(section, level) || "")
         parts << (render_subsections(section, level) || "") if with_subsections
         if with_terms
-          section.terms&.each { |term| parts << (render_term(term) || "") }
+          section.terms&.each { |term| parts << (render_term(term, level: level + 1) || "") }
         end
         render_liquid("_element.html.liquid", {
                         "tag" => "div",
@@ -164,13 +164,14 @@ module Metanorma
       # (StandardDocument::Terms::Term) and presentation-aware models with
       # fmt-* attributes (IsoDocument::Terms::IsoTerm): safe_attr returns nil
       # for attributes a model does not declare, so the fmt-* branches are
-      # skipped automatically on semantic-only models.
-      def render_term(term, **_opts)
+      # skipped automatically on semantic-only models. +level+ is the term's
+      # TermNum heading level (section level + 1, per isodoc's term_header).
+      def render_term(term, level: 2, **_opts)
         attrs = element_attrs(id: safe_attr(term, :id), **term_data_attrs(term))
         fmt_definition = safe_attr(term, :fmt_definition)
 
         parts = []
-        parts << (render_term_number(term) || "")
+        parts << (render_term_number(term, level: level) || "")
         parts << render_term_designations(term, :fmt_preferred, :preferred,
                                           "preferred")
         parts << render_term_designations(term, :fmt_admitted, :admitted,
@@ -185,7 +186,7 @@ module Metanorma
         safe_attr(term, :admonition)&.each do |admonition|
           parts << (render_admonition(admonition) || "")
         end
-        safe_attr(term, :term)&.each { |sub| parts << (render_term(sub) || "") }
+        safe_attr(term, :term)&.each { |sub| parts << (render_term(sub, level: level + 1) || "") }
         render_liquid("_element.html.liquid", {
                         "tag" => "div",
                         "extra_attrs" => attrs,
@@ -206,11 +207,15 @@ module Metanorma
         data_attrs
       end
 
-      def render_term_number(term)
+      # The term number renders as a TermNum HEADING one level below the
+      # enclosing section heading (isodoc term_header postprocess: p.TermNum
+      # becomes h(parent+1), so top-level terms get h2, nested terms h3+).
+      def render_term_number(term, level: 2)
         fmt_name = safe_attr(term, :fmt_name)
         term_number = safe_attr(term, :term_number)
         if fmt_name
           render_liquid("_term_number.html.liquid", {
+                          "level" => [level, 6].min,
                           "content" => render_inline_element(fmt_name),
                         })
         elsif term_number
@@ -220,6 +225,7 @@ module Metanorma
                           extract_text_value(term_number)
                         end
           render_liquid("_term_number.html.liquid", {
+                          "level" => [level, 6].min,
                           "content" => escape_html(number_text),
                         })
         end

--- a/lib/metanorma/html/templates/_example.html.liquid
+++ b/lib/metanorma/html/templates/_example.html.liquid
@@ -1,3 +1,3 @@
 <div{% if block.id %} id="{{ block.id }}"{% endif %} class="{{ block.css_class }}">
-<span class="example-label">{{ block.label_html }}</span>&nbsp;{{ block.content_html }}
+{{ block.content_html }}
 </div>

--- a/lib/metanorma/html/templates/_note.html.liquid
+++ b/lib/metanorma/html/templates/_note.html.liquid
@@ -1,3 +1,3 @@
 <div{% if block.id %} id="{{ block.id }}"{% endif %} class="{{ block.css_class }}">
-<span class="note-label">{{ block.label_html }}</span>&nbsp;{{ block.content_html }}
+{{ block.content_html }}
 </div>

--- a/lib/metanorma/html/templates/_term_number.html.liquid
+++ b/lib/metanorma/html/templates/_term_number.html.liquid
@@ -1,1 +1,1 @@
-<p class="term-number">{{ content }}</p>
+<h{{ level }} class="TermNum">{{ content }}</h{{ level }}>

--- a/spec/metanorma/html/generator_spec.rb
+++ b/spec/metanorma/html/generator_spec.rb
@@ -38,8 +38,8 @@ RSpec.describe Metanorma::Html::Generator do
   end
 
   describe "terms and definitions" do
-    it "renders term numbers" do
-      term_nums = page.css(".term-number")
+    it "renders term numbers as TermNum headings" do
+      term_nums = page.css(".TermNum")
       expect(term_nums.length).to be > 0
       expect(term_nums.first.text).to include("3")
     end

--- a/spec/metanorma/html/renderer/class_ownership_spec.rb
+++ b/spec/metanorma/html/renderer/class_ownership_spec.rb
@@ -13,11 +13,15 @@ RSpec.describe "HTML class name ownership" do
   let(:html) { Metanorma::Html::Generator.generate(doc) }
   let(:page) { Nokogiri::HTML(html) }
 
-  # XML-originated class names that must NEVER appear in HTML output
+  # XML-originated class names that must NEVER appear in HTML output.
+  # `TermNum` is intentionally exempt: it is the isodoc convention for
+  # the term-number heading (every fixture under spec/fixtures/iso/is/
+  # emits `<h2 class="TermNum">`), so the renderer matches it rather
+  # than inventing a parallel class.
   XML_CLASS_NAMES = %w[
     zzSTDTitle1 zzSTDTitle2 zzSTDTitle
     ForewordTitle IntroTitle
-    TermNum DeprecatedTerms Terms
+    DeprecatedTerms Terms
     Note Example
     Section3 Section3Sub
     Annex
@@ -67,9 +71,8 @@ RSpec.describe "HTML class name ownership" do
     expect(page.at_css("figure")).not_to be_nil
   end
 
-  it "uses term-number class instead of TermNum" do
-    expect(page.at_css(".term-number")).not_to be_nil
-    expect(page.at_css(".TermNum")).to be_nil
+  it "renders term numbers as TermNum headings (isodoc convention)" do
+    expect(page.at_css("h2.TermNum, h3.TermNum")).not_to be_nil
   end
 
   it "uses foreword-title class instead of ForewordTitle" do

--- a/spec/metanorma/html/renderer/liquid_templates_spec.rb
+++ b/spec/metanorma/html/renderer/liquid_templates_spec.rb
@@ -152,10 +152,11 @@ RSpec.describe "Liquid templates" do
   end
 
   describe "_term_number.html.liquid" do
-    it "renders term number" do
-      html = render_template("term_number", { "content" => "3.1" })
+    it "renders term number as a TermNum heading" do
+      html = render_template("term_number", { "level" => 2, "content" => "3.1" })
       expect(html).to include("3.1")
-      expect(html).to include("term-number")
+      expect(html).to include("TermNum")
+      expect(html).to include("<h2")
     end
   end
 

--- a/spec/metanorma/html/renderer/section_rendering_spec.rb
+++ b/spec/metanorma/html/renderer/section_rendering_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "Section rendering consolidation" do
   end
 
   it "renders terms section with term entries" do
-    terms = page.css(".term-name, .term-number")
+    terms = page.css(".term-name, .TermNum")
     expect(terms.length).to be > 0
   end
 end

--- a/spec/metanorma/html/renderer/standard_renderer_spec.rb
+++ b/spec/metanorma/html/renderer/standard_renderer_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe Metanorma::Html::StandardRenderer do
       expect(headings.length).to be > 0
     end
 
-    it "renders terms sections with term-number entries" do
-      expect(page.at_css(".term-number")).not_to be_nil
+    it "renders terms sections with TermNum headings" do
+      expect(page.at_css(".TermNum")).not_to be_nil
     end
 
     it "renders foreword with foreword-title class" do


### PR DESCRIPTION
## Summary

- Term numbers now render as `<h2>/<h3 class="TermNum">` headings instead of `<p class="term-number">`, matching the isodoc convention used by every fixture under `spec/fixtures/iso/is/`.
- `NOTE` and `EXAMPLE` labels open the first paragraph instead of floating outside it (isodoc convention: `<p><span class="note-label">NOTE</span> text...</p>`).
- CSS `.term-number` rules renamed `.TermNum` across the base (`_dark.css`, `_print.css`) and component (`term.css`) stylesheets.

Heading level is `section_level + 1` per isodoc's `term_header` postprocess (top-level terms get `<h2>`, nested terms `<h3>`).

## Why

The previous renderer diverged from the isodoc HTML fixtures on two counts: term numbers were paragraphs (fixtures use headings), and block labels floated outside the first paragraph (fixtures put them inside). Aligning the renderer with the fixtures lets downstream tooling (including the OIML STS parity validator) compare content directly.

## Test plan

- [x] `bundle exec rspec spec/metanorma/html/` — 385 examples, 0 failures.
- [x] `bundle exec rubocop lib/metanorma/html/drops lib/metanorma/html/standard_renderer.rb` — clean.
- [x] Parity validator (in `metanorma-oiml`) reports 100% paragraph coverage against the new output.
