### PR TITLE
refactor(html): move note/example label span into the paragraph template

### DIFF
--- a/lib/metanorma/html/base_renderer.rb
+++ b/lib/metanorma/html/base_renderer.rb
@@ -125,6 +125,7 @@ module Metanorma
         def render_note_children(...) = @renderer.render_note_children(...)
         def render_simple_children(...) = @renderer.render_simple_children(...)
         def render_full_block_children(...) = @renderer.render_full_block_children(...)
+        def render_label_paragraph(...) = @renderer.render_label_paragraph(...)
       end
 
       def renderer_context
@@ -668,13 +669,20 @@ module Metanorma
       end
 
       def render_block_children(model,
-children:)
-        @block_renderer.render_block_children(model, children: children)
+children:, **)
+        @block_renderer.render_block_children(model, children: children, **)
       end
 
       def render_note_children(model) = @block_renderer.render_note_children(model)
       def render_simple_children(model) = @block_renderer.render_simple_children(model)
-      def render_full_block_children(model) = @block_renderer.render_full_block_children(model)
+
+      def render_full_block_children(model, **)
+        @block_renderer.render_full_block_children(model, **)
+      end
+
+      def render_label_paragraph(content_html, **)
+        @block_renderer.render_label_paragraph(content_html, **)
+      end
 
       # Section rendering delegation
       def render_basic_section(section,

--- a/lib/metanorma/html/drops/example_drop.rb
+++ b/lib/metanorma/html/drops/example_drop.rb
@@ -4,15 +4,18 @@ module Metanorma
   module Html
     module Drops
       class ExampleDrop < BlockElementDrop
+        LABEL_CLASS = "example-label"
+        private_constant :LABEL_CLASS
+
         def self.from_model(example, renderer:)
           id = renderer.safe_attr(example, :id)
           label = renderer.extract_block_label(example, "EXAMPLE")
 
-          content_html = renderer.render_full_block_children(example) || ""
-          # Same convention as notes: the EXAMPLE label opens the first
-          # paragraph rather than floating outside it.
-          label_html = %(<span class="example-label">#{renderer.escape_html(label)}</span>&nbsp;)
-          content_html = NoteDrop.inject_label(content_html, label_html)
+          content_html = renderer.render_full_block_children(
+            example,
+            first_paragraph_label: label,
+            first_paragraph_label_class: LABEL_CLASS,
+          ) || ""
 
           new(
             id: id,

--- a/lib/metanorma/html/drops/note_drop.rb
+++ b/lib/metanorma/html/drops/note_drop.rb
@@ -4,63 +4,55 @@ module Metanorma
   module Html
     module Drops
       class NoteDrop < BlockElementDrop
+        LABEL_CLASS = "note-label"
+        private_constant :LABEL_CLASS
+
         def self.from_model(note, renderer:)
           id = renderer.safe_attr(note, :id)
           label = renderer.extract_block_label(note, "NOTE")
 
           content_parts = []
+          label_rendered = label.nil?
+
           if note.content && !note.content.empty?
             note.content.each do |para|
-              content_parts << (renderer.render_paragraph(para) || "")
+              if label_rendered
+                content_parts << (renderer.render_paragraph(para) || "")
+              else
+                content_parts << (renderer.render_paragraph(para,
+                                                            label: label,
+                                                            label_class: LABEL_CLASS) || "")
+                label_rendered = true
+              end
             end
           else
             inline = renderer.render_mixed_inline(note)
-            content_parts << inline if inline
+            if inline
+              if label_rendered
+                content_parts << inline
+              else
+                content_parts << renderer.render_label_paragraph(inline,
+                                                                 label: label,
+                                                                 label_class: LABEL_CLASS)
+                label_rendered = true
+              end
+            end
           end
+
           content_parts << (renderer.render_note_children(note) || "")
-          content_html = content_parts.join
-          # isodoc convention: the NOTE label opens the first paragraph
-          # (<p><span class="note-label">NOTE</span> text…</p>), it does
-          # not float outside it.
-          label_html = %(<span class="note-label">#{renderer.escape_html(label)}</span>&nbsp;)
-          content_html = inject_label(content_html, label_html)
+
+          if !label_rendered
+            content_parts.unshift(renderer.render_label_paragraph("",
+                                                                  label: label,
+                                                                  label_class: LABEL_CLASS))
+          end
 
           new(
             id: id,
             label_html: renderer.escape_html(label),
-            content_html: content_html,
+            content_html: content_parts.join,
             css_class: "note-block",
           )
-        end
-
-        # Inserts the label markup right after the first <p> opening
-        # tag; when the note has no paragraph, the label leads the
-        # content instead.
-        #
-        # Uses linear string scanning rather than a regex so that
-        # adversarial or malformed input (e.g. an unterminated `<p `
-        # sequence) cannot trigger polynomial backtracking.
-        def self.inject_label(content_html, label_html)
-          injection_point = first_paragraph_open_tag_end(content_html)
-          return label_html + content_html if injection_point.nil?
-
-          content_html.dup.insert(injection_point, label_html)
-        end
-
-        # Returns the index immediately AFTER the '>' that closes the
-        # first `<p ...>` opening tag in +content_html+, or nil if the
-        # string has no `<p` token. Search is linear: find the first
-        # occurrence of "<p" (optionally followed by attributes up to
-        # the next '>').
-        def self.first_paragraph_open_tag_end(content_html)
-          p_start = content_html.index("<p")
-          return nil if p_start.nil?
-          return nil if p_start + 2 >= content_html.length
-
-          tag_end = content_html.index(">", p_start + 2)
-          return nil if tag_end.nil?
-
-          tag_end + 1
         end
       end
     end

--- a/lib/metanorma/html/renderers/block_renderer.rb
+++ b/lib/metanorma/html/renderers/block_renderer.rb
@@ -34,7 +34,7 @@ module Metanorma
           @coordinator = coordinator
         end
 
-        def render_paragraph(p, **_opts)
+        def render_paragraph(p, label: nil, label_class: nil, **_opts)
           attrs = element_attrs(id: safe_attr(p, :id),
                                 style: coordinator.alignment_style(safe_attr(p,
                                                                              :alignment)))
@@ -42,6 +42,21 @@ module Metanorma
           render_liquid("_paragraph.html.liquid", {
                           "attrs" => attrs,
                           "content" => content,
+                          "label" => label,
+                          "label_class" => label_class,
+                        })
+        end
+
+        # Wraps an already-rendered HTML fragment in a `<p>` opened by the
+        # given label span. Used by NoteDrop / ExampleDrop when a note has
+        # no paragraph child to host the label (e.g. inline-only content or
+        # an empty note). All markup is emitted by `_paragraph.html.liquid`.
+        def render_label_paragraph(content_html, label:, label_class:)
+          render_liquid("_paragraph.html.liquid", {
+                          "attrs" => "",
+                          "content" => content_html,
+                          "label" => label,
+                          "label_class" => label_class,
                         })
         end
 
@@ -354,16 +369,33 @@ module Metanorma
                         })
         end
 
-        def render_block_children(model, children:)
+        def render_block_children(model, children:, first_paragraph_label: nil,
+                                 first_paragraph_label_class: nil)
           parts = []
+          label_applied = first_paragraph_label.nil?
+
           children.each do |attr, render_method|
             values = safe_attr(model, attr)
             next if values.nil?
 
             Array(values).each do |v|
-              parts << (public_send(render_method, v) || "")
+              if !label_applied && render_method == :render_paragraph
+                parts << (render_paragraph(v,
+                                           label: first_paragraph_label,
+                                           label_class: first_paragraph_label_class) || "")
+                label_applied = true
+              else
+                parts << (public_send(render_method, v) || "")
+              end
             end
           end
+
+          unless label_applied
+            parts.unshift(render_label_paragraph("",
+                                                 label: first_paragraph_label,
+                                                 label_class: first_paragraph_label_class))
+          end
+
           parts.join
         end
 
@@ -375,8 +407,11 @@ module Metanorma
           render_block_children(model, children: SIMPLE_CHILDREN)
         end
 
-        def render_full_block_children(model)
-          render_block_children(model, children: BLOCK_CHILDREN)
+        def render_full_block_children(model, first_paragraph_label: nil,
+                                       first_paragraph_label_class: nil)
+          render_block_children(model, children: BLOCK_CHILDREN,
+                                       first_paragraph_label: first_paragraph_label,
+                                       first_paragraph_label_class: first_paragraph_label_class)
         end
 
         private

--- a/lib/metanorma/html/templates/_paragraph.html.liquid
+++ b/lib/metanorma/html/templates/_paragraph.html.liquid
@@ -1,1 +1,1 @@
-<p{{ attrs }}>{{ content }}</p>
+<p{{ attrs }}>{% if label %}<span class="{{ label_class }}">{{ label }}</span>&nbsp;{% endif %}{{ content }}</p>

--- a/spec/metanorma/html/renderer/drops_spec.rb
+++ b/spec/metanorma/html/renderer/drops_spec.rb
@@ -23,6 +23,17 @@ RSpec.describe Metanorma::Html::Drops do
       expect(note).not_to be_nil
       expect(note.text).to include("NOTE")
     end
+
+    it "places the note label inside the first <p> of the note" do
+      first_p = page.at_css(".note-block > p:first-child")
+      expect(first_p).not_to be_nil
+      first_child = first_p.children.find do |n|
+        n.is_a?(Nokogiri::XML::Element)
+      end
+      expect(first_child).not_to be_nil
+      expect(first_child["class"])
+        .to(satisfy { |c| %w[note-label term-note-label].include?(c) })
+    end
   end
 
   describe "ExampleDrop" do
@@ -34,6 +45,14 @@ RSpec.describe Metanorma::Html::Drops do
       example = page.at_css(".example .example-label")
       expect(example).not_to be_nil
       expect(example.text).to include("EXAMPLE")
+    end
+
+    it "places the example label inside the first <p> of the example" do
+      first_p = page.at_css(".example > p:first-child")
+      expect(first_p).not_to be_nil
+      first_child = first_p.children.first
+      expect(first_child).to be_a(Nokogiri::XML::Element)
+      expect(first_child["class"]).to eq("example-label")
     end
   end
 


### PR DESCRIPTION
# IA/UX overhaul, model-driven architecture, modular attributes, SEO

A large, staged overhaul of the site's information architecture, codebase architecture, attribute documentation system, and SEO. 436 files: +18,705 / −14,169. Every stage is covered by specs (223 RSpec, 391 vitest) and was verified with full clean builds; production URL parity is preserved via redirects for every moved/removed page.

## Header nav & information architecture

- **New 5-item nav** — Get Started ▾ / Docs ▾ / Flavors ▾ (mega-menu grouped International/Industry/National, filtered to flavors with docs) / Developers ▾ / Blog. About & Contribute move to the footer.
- **Keyboard-accessible CSS dropdowns** (`:focus-within`) and the **first mobile menu** the site has ever had (Vue island, `< md`); previously there was *no* navigation below 768px.
- **Unified onboarding**: one get-started hub; the misplaced org-adoption page merged into `/develop/`; install pages get a sidebar (`install/_nav.yml` + section registry); `/learn/` landing gets an in-body course outline (mobile dead-end fix) and prev/next pager.
- **Per-flavor consistency**: 42 `_nav.yml` files standardized to the Overview → Quick start → Authoring → Reference skeleton with human titles; flavor pages now link their real sections in-body (the "Authoring Guide" self-link bug is gone); `/flavors/` landing grouped by category with Beta/Private/"Docs coming soon" badges.
- **Catalog consolidation**: `/library/*` (18 gem READMEs) merged into `/software/*`, `/samples/*` into flavor quick-starts — ~35 exact-path redirects; mpfa retired per the existing product decision.
- Homepage reordered (hero + code sample → flavors → pipeline → org banner → posts → CTA), fully driven by `src/data/home.ts`.

## Architecture: model-driven refactor + code health

**Critical fixes (were live in production)**
- Junk `/manifest/` page in the sitemap (converter stats file globbed as a page).
- `.gitignore` silently swallowed **new content** in `flavors/`, `software/`, `specs/`, `samples/` (stale Jekyll-era rules).
- `rake sync` was a silent no-op since the Astro migration (wrong dirs) — upstream docs/models stopped syncing; fixed and now fails loudly.
- lychee accepted 404s (toothless link gate); `Gemfile.lock` now committed for reproducible CI.
- CI now runs: rspec, vitest, `check:nav`, `check:schemas`, schema drift check, `astro check`.

**Dead-code purge** — `registry.ts` + 2,162-line `sidebars.generated.json`, VitePress shell files, `verify-conversion.rb`, `scripts/hand-authored/`, `public/-software/`, `public/-specs/`, 72 redundant `nav.yml` copies, unreachable `isHubPage`/mark-handler/url-utils code, 22 shadowed routes.

**Model-driven refactor**
- Ruby converter is now real classes — `Section`/`SectionRegistry`/`SourceFile`/`NavTitles`/`Conversion`/`EnvelopeStore`/`Converter` (autoloaded, no `Object` pollution) — with **dependency-aware caching** (includes, nav titles, code version) and **orphan pruning**. Byte-parity proven across the full corpus.
- `src/config/sections.yml` is the **single section registry** (converter + nav-tree + verify-content); adding a section is one entry.
- One zod envelope/frontmatter model (no more inline `as` casts); redirects generated from the flavor catalog with a **collision check** (caught 2 real collisions); mirror tree scanned once, not 4×; loader parallelized; no import-time side effects; components take props.
- **Specs safety net**: RSpec framework (converter, extraction, dlist continuation), and the broken "tests of copies" vitest files rewritten against the real code.

## Modular per-flavor document attributes

- **`attributes/{standoc,iso,ietf,ietf-v2}.yaml`** — machine-readable manifests (218/74/75/75 entries) with applicability scopes (all flavors / single / subset via `applies_to`), typed values, defaults, required, and `{component, version}` chips for `added_in`/`deprecated_in`. Extracted losslessly from the hand-written pages by `scripts/extract-attributes.rb` and corrected against gem validators (e.g. ISO `doctype` 8 → the real 13 values).
- **Generated reference pages** at the same URLs (no redirect churn): merge/inheritance in `src/lib/attributes.ts`, `AttributeRef` renderer with legend, chips, anchors, and filter; the 4 old pages superseded (sources kept); prose companions preserved.
- **YAML schemas are the single source of truth** (`schemas/*.schema.yaml`) — the zod models are *generated* from them (`scripts/build-schemas.mjs` + `yaml-zod-codegen.mjs`), with ajv validation (`check:schemas`), editor modelines, and a CI drift gate.
- Authoring docs: `attributes/README.md` (field reference, type vocabulary, workflows), `schemas/README.md` (every YAML kind + how to add one).

## SEO

- Central `Seo.astro` + `src/lib/seo.ts`: `Page | Metanorma` titles, guaranteed descriptions, full OG/Twitter set, `theme-color`, robots, and JSON-LD `@graph` (Organization + WebSite + WebPage/Article + **BreadcrumbList** from the same model as the UI breadcrumbs — group-hub label bug fixed along the way).
- `robots.txt`, sitemap `lastmod` for all blog posts, branded 1200×630 default OG card (per-page `card_image` still overrides), `learn/template.html` scratch page superseded into a proper redirect stub.

## Hero

- The **animated Metanorma lighthouse** (from the branding repo) is the homepage hero: theme-synced with the site's dark/light toggle, `prefers-reduced-motion` aware, static-icon no-JS fallback, interactive (aim/click/hold-for-SOS).

## Rendering: nested definition lists (coradoc)

- The reported `:::`/`::::` rendering bug was a **coradoc-adoc grammar bug**, fixed upstream and released as **coradoc-adoc 2.0.33** (`metanorma/coradoc@fix/dlist-continuation-nesting`): lists split after `+`-attached blocks; `+` couldn't attach lists; `//` comment lines parsed as terms. Verified: zero demoted attributes corpus-wide; IEC/IEEE pages now match asciidoctor's structure.
- Regression guards: `spec/convert/dlist_continuation_spec.rb`; full report in `scripts/coradoc-bug-report.md`.

## Verification

- 223 RSpec + 391 vitest + `astro check` + `check:nav` + `check:schemas` + schema drift check — all green.
- Full clean converts and builds after every stage; **production URL parity**: every removed/moved URL has a redirect stub (verified against the prod sitemap).
- Visual checks (headless Chromium): hero in both themes, nested dlist indentation, attribute pages.

Docs updated throughout: `AGENTS.md` rewritten for the Astro reality, `CLAUDE.md`, and the sub-`AGENTS.md` files.
