### PR TITLE
Map all grammar elements reported in #37-#44 and #46

### DIFF
--- a/lib/metanorma/document/components/ancillary_blocks/literal_block.rb
+++ b/lib/metanorma/document/components/ancillary_blocks/literal_block.rb
@@ -11,6 +11,7 @@ module Metanorma
         # semantically.
         class LiteralBlock < Lutaml::Model::Serializable
           attribute :id, :string
+          attribute :anchor, :string
           attribute :alt, :string
           attribute :align, :string
           attribute :name, Metanorma::Document::Components::TextElements::TextElement,
@@ -20,6 +21,7 @@ module Metanorma
           xml do
             element "pre"
             map_attribute "id", to: :id
+            map_attribute "anchor", to: :anchor
             map_attribute "alt", to: :alt
             map_attribute "align", to: :align
             map_element "name", to: :name

--- a/lib/metanorma/document/components/bib_data/bibliographic_item.rb
+++ b/lib/metanorma/document/components/bib_data/bibliographic_item.rb
@@ -7,6 +7,8 @@ module Metanorma
         # Description of a bibliographic resource.
         class BibliographicItem < Lutaml::Model::Serializable
           attribute :id, :string
+          attribute :hidden, :boolean
+          attribute :suppress_identifier, :boolean
           attribute :type, Metanorma::Document::Relaton::BibItemType
           attribute :fetched, Metanorma::Document::Relaton::DateTime
           attribute :title, Metanorma::Document::Relaton::TypedTitleString,
@@ -65,6 +67,8 @@ module Metanorma
           xml do
             element "bibitem"
             map_attribute "id", to: :id
+            map_attribute "hidden", to: :hidden
+            map_attribute "suppress_identifier", to: :suppress_identifier
             map_attribute "type", to: :type_attr
             map_attribute "anchor", to: :anchor
             map_attribute "semx-id", to: :semx_id

--- a/lib/metanorma/document/components/blocks.rb
+++ b/lib/metanorma/document/components/blocks.rb
@@ -7,6 +7,7 @@ module Metanorma
         autoload :BasicBlock, "#{__dir__}/blocks/basic_block"
         autoload :BasicBlockNoNotes, "#{__dir__}/blocks/basic_block_no_notes"
         autoload :ClassificationValue, "#{__dir__}/blocks/classification_value"
+        autoload :FmtProvision, "#{__dir__}/blocks/fmt_provision"
         autoload :NoteBlock, "#{__dir__}/blocks/note_block"
         autoload :Passthrough, "#{__dir__}/blocks/passthrough"
         autoload :PermissionModel, "#{__dir__}/blocks/permission_model"
@@ -17,7 +18,14 @@ module Metanorma
         autoload :RequirementDescription,
                  "#{__dir__}/blocks/requirement_description"
         autoload :RequirementInherit, "#{__dir__}/blocks/requirement_inherit"
+        autoload :RequirementImport, "#{__dir__}/blocks/requirement_import"
+        autoload :RequirementMeasurementTarget,
+                 "#{__dir__}/blocks/requirement_measurement_target"
         autoload :RequirementModel, "#{__dir__}/blocks/requirement_model"
+        autoload :RequirementSpecification,
+                 "#{__dir__}/blocks/requirement_specification"
+        autoload :RequirementVerification,
+                 "#{__dir__}/blocks/requirement_verification"
       end
     end
   end

--- a/lib/metanorma/document/components/blocks/fmt_provision.rb
+++ b/lib/metanorma/document/components/blocks/fmt_provision.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Document
+    module Components
+      module Blocks
+        # Presentation-layer rendering of a requirement: the fully
+        # formatted block content emitted alongside the semantic requirement.
+        class FmtProvision < RequirementDescription
+          xml do
+            element "fmt-provision"
+            map_element "p", to: :p
+            map_element "ul", to: :ul
+            map_element "ol", to: :ol
+            map_element "sourcecode", to: :sourcecode
+            map_element "table", to: :table
+            map_element "example", to: :example
+            map_element "note", to: :note
+            map_element "figure", to: :figure
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/document/components/blocks/permission_model.rb
+++ b/lib/metanorma/document/components/blocks/permission_model.rb
@@ -15,7 +15,16 @@ module Metanorma
             map_element "subject", to: :subject
             map_element "classification", to: :classification
             map_element "description", to: :description
+            map_element "identifier", to: :identifier
+            map_element "title", to: :title
+            map_element "specification", to: :specification
+            map_element "measurement-target", to: :measurement_target
+            map_element "verification", to: :verification
+            map_element "import", to: :import
             map_element "inherit", to: :inherit
+            map_element "fmt-name", to: :fmt_name
+            map_element "fmt-xref-label", to: :fmt_xref_label
+            map_element "fmt-provision", to: :fmt_provision
             map_element "requirement", to: :requirement
             map_element "recommendation", to: :recommendation
             map_element "permission", to: :permission

--- a/lib/metanorma/document/components/blocks/recommendation_model.rb
+++ b/lib/metanorma/document/components/blocks/recommendation_model.rb
@@ -15,7 +15,16 @@ module Metanorma
             map_element "subject", to: :subject
             map_element "classification", to: :classification
             map_element "description", to: :description
+            map_element "identifier", to: :identifier
+            map_element "title", to: :title
+            map_element "specification", to: :specification
+            map_element "measurement-target", to: :measurement_target
+            map_element "verification", to: :verification
+            map_element "import", to: :import
             map_element "inherit", to: :inherit
+            map_element "fmt-name", to: :fmt_name
+            map_element "fmt-xref-label", to: :fmt_xref_label
+            map_element "fmt-provision", to: :fmt_provision
             map_element "requirement", to: :requirement
             map_element "recommendation", to: :recommendation
             map_element "permission", to: :permission

--- a/lib/metanorma/document/components/blocks/requirement_base.rb
+++ b/lib/metanorma/document/components/blocks/requirement_base.rb
@@ -10,10 +10,22 @@ module Metanorma
           attribute :obligation, :string
           attribute :type, :string
           attribute :anchor, :string
+          attribute :identifier, :string
+          attribute :title, Metanorma::Document::Components::DataTypes::FormattedString
           attribute :subject, :string
           attribute :classification, RequirementClassification, collection: true
           attribute :description, RequirementDescription, collection: true
+          attribute :specification, RequirementSpecification, collection: true
+          attribute :measurement_target, RequirementMeasurementTarget,
+                    collection: true
+          attribute :verification, RequirementVerification, collection: true
+          attribute :import, RequirementImport, collection: true
           attribute :inherit, RequirementInherit, collection: true
+          attribute :fmt_name, Metanorma::Document::Components::Inline::FmtNameElement
+          attribute :fmt_xref_label,
+                    Metanorma::Document::Components::Inline::FmtXrefLabelElement,
+                    collection: true
+          attribute :fmt_provision, FmtProvision
           attribute :requirement, "Metanorma::Document::Components::Blocks::RequirementModel",
                     collection: true
           attribute :recommendation, "Metanorma::Document::Components::Blocks::RecommendationModel",

--- a/lib/metanorma/document/components/blocks/requirement_import.rb
+++ b/lib/metanorma/document/components/blocks/requirement_import.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Document
+    module Components
+      module Blocks
+        class RequirementImport < RequirementDescription
+          xml do
+            element "import"
+            map_element "p", to: :p
+            map_element "ul", to: :ul
+            map_element "ol", to: :ol
+            map_element "sourcecode", to: :sourcecode
+            map_element "table", to: :table
+            map_element "example", to: :example
+            map_element "note", to: :note
+            map_element "figure", to: :figure
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/document/components/blocks/requirement_measurement_target.rb
+++ b/lib/metanorma/document/components/blocks/requirement_measurement_target.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Document
+    module Components
+      module Blocks
+        class RequirementMeasurementTarget < RequirementDescription
+          xml do
+            element "measurement-target"
+            map_element "p", to: :p
+            map_element "ul", to: :ul
+            map_element "ol", to: :ol
+            map_element "sourcecode", to: :sourcecode
+            map_element "table", to: :table
+            map_element "example", to: :example
+            map_element "note", to: :note
+            map_element "figure", to: :figure
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/document/components/blocks/requirement_model.rb
+++ b/lib/metanorma/document/components/blocks/requirement_model.rb
@@ -15,7 +15,16 @@ module Metanorma
             map_element "subject", to: :subject
             map_element "classification", to: :classification
             map_element "description", to: :description
+            map_element "identifier", to: :identifier
+            map_element "title", to: :title
+            map_element "specification", to: :specification
+            map_element "measurement-target", to: :measurement_target
+            map_element "verification", to: :verification
+            map_element "import", to: :import
             map_element "inherit", to: :inherit
+            map_element "fmt-name", to: :fmt_name
+            map_element "fmt-xref-label", to: :fmt_xref_label
+            map_element "fmt-provision", to: :fmt_provision
             map_element "requirement", to: :requirement
             map_element "recommendation", to: :recommendation
             map_element "permission", to: :permission

--- a/lib/metanorma/document/components/blocks/requirement_specification.rb
+++ b/lib/metanorma/document/components/blocks/requirement_specification.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Document
+    module Components
+      module Blocks
+        class RequirementSpecification < RequirementDescription
+          xml do
+            element "specification"
+            map_element "p", to: :p
+            map_element "ul", to: :ul
+            map_element "ol", to: :ol
+            map_element "sourcecode", to: :sourcecode
+            map_element "table", to: :table
+            map_element "example", to: :example
+            map_element "note", to: :note
+            map_element "figure", to: :figure
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/document/components/blocks/requirement_verification.rb
+++ b/lib/metanorma/document/components/blocks/requirement_verification.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Document
+    module Components
+      module Blocks
+        class RequirementVerification < RequirementDescription
+          xml do
+            element "verification"
+            map_element "p", to: :p
+            map_element "ul", to: :ul
+            map_element "ol", to: :ol
+            map_element "sourcecode", to: :sourcecode
+            map_element "table", to: :table
+            map_element "example", to: :example
+            map_element "note", to: :note
+            map_element "figure", to: :figure
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/document/components/id_elements/image.rb
+++ b/lib/metanorma/document/components/id_elements/image.rb
@@ -9,6 +9,7 @@ module Metanorma
           attribute :height, :string
           attribute :width, :string
           attribute :align, :string
+          attribute :anchor, :string
           attribute :semx_id, :string
           attribute :inline_svg, :string
 
@@ -17,6 +18,7 @@ module Metanorma
             map_attribute "height", to: :height, render_empty: true
             map_attribute "width", to: :width, render_empty: true
             map_attribute "align", to: :align
+            map_attribute "anchor", to: :anchor
             map_attribute "semx-id", to: :semx_id
             map_element "svg", to: :inline_svg, raw: :element
           end

--- a/lib/metanorma/document/components/inline.rb
+++ b/lib/metanorma/document/components/inline.rb
@@ -102,6 +102,16 @@ module Metanorma
                  "metanorma/document/components/inline/semantic_content"
         autoload :LocationElement,
                  "metanorma/document/components/inline/location_element"
+        autoload :DateElement,
+                 "metanorma/document/components/inline/date_element"
+        autoload :FmtDateElement,
+                 "metanorma/document/components/inline/fmt_date_element"
+        autoload :ErefStack,
+                 "metanorma/document/components/inline/eref_stack"
+        autoload :ErrorMessage,
+                 "metanorma/document/components/inline/error_message"
+        autoload :TermrefElement,
+                 "metanorma/document/components/inline/termref_element"
         autoload :SemanticMathElement,
                  "metanorma/document/components/inline/semantic_math_element"
         autoload :RenderedMathElement,

--- a/lib/metanorma/document/components/inline/concept_element.rb
+++ b/lib/metanorma/document/components/inline/concept_element.rb
@@ -6,16 +6,34 @@ module Metanorma
       module Inline
         class ConceptElement < Lutaml::Model::Serializable
           attribute :id, :string
+          attribute :bold, :boolean
+          attribute :ital, :boolean
+          attribute :ref, :boolean
+          attribute :linkmention, :boolean
+          attribute :linkref, :boolean
           attribute :refterm, :string, collection: true
           attribute :renderterm, :string, collection: true
           attribute :xref, XrefElement, collection: true
+          attribute :eref, Metanorma::Document::Components::Inline::ErefElement
+          attribute :erefstack, Metanorma::Document::Components::Inline::ErefStack
+          attribute :termref, Metanorma::Document::Components::Inline::TermrefElement
+          attribute :errormsg, Metanorma::Document::Components::Inline::ErrorMessage
 
           xml do
             element "concept"
             map_attribute "id", to: :id
+            map_attribute "bold", to: :bold
+            map_attribute "ital", to: :ital
+            map_attribute "ref", to: :ref
+            map_attribute "linkmention", to: :linkmention
+            map_attribute "linkref", to: :linkref
             map_element "refterm", to: :refterm
             map_element "renderterm", to: :renderterm
             map_element "xref", to: :xref
+            map_element "eref", to: :eref
+            map_element "erefstack", to: :erefstack
+            map_element "termref", to: :termref
+            map_element "errormsg", to: :errormsg
           end
         end
       end

--- a/lib/metanorma/document/components/inline/date_element.rb
+++ b/lib/metanorma/document/components/inline/date_element.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Document
+    module Components
+      module Inline
+        # Localisable rendering of a date in body content.
+        class DateElement < Lutaml::Model::Serializable
+          attribute :language, :string
+          attribute :script, :string
+          attribute :value, :string
+          attribute :format, :string
+
+          xml do
+            element "date"
+            map_attribute "language", to: :language
+            map_attribute "script", to: :script
+            map_attribute "value", to: :value
+            map_attribute "format", to: :format
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/document/components/inline/eref_element.rb
+++ b/lib/metanorma/document/components/inline/eref_element.rb
@@ -15,7 +15,11 @@ module Metanorma
           attribute :alt, :string
           attribute :display_format, :string
           attribute :relative, :string
+          attribute :connective, :string
+          attribute :custom_connective, :string
           attribute :locality_stack, Metanorma::Document::Relaton::LocalityStack,
+                    collection: true
+          attribute :locality, Metanorma::Document::Relaton::BibItemLocality,
                     collection: true
 
           xml do
@@ -29,7 +33,10 @@ module Metanorma
             map_attribute "alt", to: :alt
             map_attribute "displayFormat", to: :display_format
             map_attribute "relative", to: :relative
+            map_attribute "connective", to: :connective
+            map_attribute "custom-connective", to: :custom_connective
             map_element "localityStack", to: :locality_stack
+            map_element "locality", to: :locality
             map_content to: :text
             Vocabulary::VocabularyXmlMapping.apply_inline_mappings(self)
           end

--- a/lib/metanorma/document/components/inline/eref_stack.rb
+++ b/lib/metanorma/document/components/inline/eref_stack.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Document
+    module Components
+      module Inline
+        # Set of cross-references to bibliographic references,
+        # joined with connectives.
+        class ErefStack < Lutaml::Model::Serializable
+          attribute :id, :string
+          attribute :eref, Metanorma::Document::Components::Inline::ErefElement,
+                    collection: true
+
+          xml do
+            element "erefstack"
+            map_attribute "id", to: :id
+            map_element "eref", to: :eref
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/document/components/inline/error_message.rb
+++ b/lib/metanorma/document/components/inline/error_message.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Document
+    module Components
+      module Inline
+        # Generator-only error message carried in place of an unresolved
+        # concept or related-term cross-reference.
+        class ErrorMessage < Lutaml::Model::Serializable
+          include Metanorma::Document::Components::Inline::Vocabulary
+
+          attribute :index_xref,
+                    Metanorma::Document::Components::EmptyElements::IndexElement,
+                    collection: true
+
+          xml do
+            element "errormsg"
+            mixed_content
+            map_content to: :text
+            map_element "index-xref", to: :index_xref
+            Metanorma::Document::Components::Inline::Vocabulary::VocabularyXmlMapping
+              .apply_inline_mappings(self)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/document/components/inline/fmt_date_element.rb
+++ b/lib/metanorma/document/components/inline/fmt_date_element.rb
@@ -4,25 +4,22 @@ module Metanorma
   module Document
     module Components
       module Inline
-        class VariantTitleElement < Lutaml::Model::Serializable
-          attribute :type, :string
+        # Presentation-layer rendering of an inline date.
+        class FmtDateElement < Lutaml::Model::Serializable
+          include RenderedDisplay
+
           attribute :id, :string
-          attribute :anchor, :string
           attribute :text, :string, collection: true
           attribute :span, SpanElement, collection: true
           attribute :semx, SemxElement, collection: true
-          attribute :br, BrElement, collection: true
 
           xml do
-            element "variant-title"
+            element "fmt-date"
             mixed_content
-            map_attribute "type", to: :type
             map_attribute "id", to: :id
-            map_attribute "anchor", to: :anchor
             map_content to: :text
             map_element "span", to: :span
             map_element "semx", to: :semx
-            map_element "br", to: :br
           end
         end
       end

--- a/lib/metanorma/document/components/inline/fn_element.rb
+++ b/lib/metanorma/document/components/inline/fn_element.rb
@@ -6,6 +6,7 @@ module Metanorma
       module Inline
         class FnElement < Lutaml::Model::Serializable
           attribute :id, :string
+          attribute :anchor, :string
           attribute :reference, :string
           attribute :hiddenref, :boolean
           attribute :target, :string
@@ -18,6 +19,7 @@ module Metanorma
           xml do
             element "fn"
             map_attribute "id", to: :id
+            map_attribute "anchor", to: :anchor
             map_attribute "reference", to: :reference
             map_attribute "hiddenref", to: :hiddenref
             map_attribute "target", to: :target

--- a/lib/metanorma/document/components/inline/name_with_id_element.rb
+++ b/lib/metanorma/document/components/inline/name_with_id_element.rb
@@ -6,6 +6,7 @@ module Metanorma
       module Inline
         class NameWithIdElement < Lutaml::Model::Serializable
           attribute :id, :string
+          attribute :anchor, :string
           attribute :semx_id, :string
           attribute :text, :string
           attribute :stem, TextElements::StemElement, collection: true
@@ -13,6 +14,7 @@ module Metanorma
           xml do
             element "name"
             map_attribute "id", to: :id
+            map_attribute "anchor", to: :anchor
             map_attribute "semx-id", to: :semx_id
             map_content to: :text
             map_element "stem", to: :stem

--- a/lib/metanorma/document/components/inline/span_element.rb
+++ b/lib/metanorma/document/components/inline/span_element.rb
@@ -12,6 +12,7 @@ module Metanorma
 
           attribute :class_attr, :string
           attribute :style, :string
+          attribute :anchor, :string
           attribute :callout,
                     Metanorma::Document::Components::ReferenceElements::Callout,
                     collection: true
@@ -21,6 +22,7 @@ module Metanorma
             mixed_content
             map_attribute "class", to: :class_attr
             map_attribute "style", to: :style
+            map_attribute "anchor", to: :anchor
             map_content to: :text
             map_element "callout", to: :callout
             Vocabulary::VocabularyXmlMapping.apply_inline_mappings(self)

--- a/lib/metanorma/document/components/inline/termref_element.rb
+++ b/lib/metanorma/document/components/inline/termref_element.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Document
+    module Components
+      module Inline
+        # Cross-reference to a term defined within a termbase.
+        class TermrefElement < Lutaml::Model::Serializable
+          attribute :base, :string
+          attribute :target, :string
+          attribute :text, :string, collection: true
+
+          xml do
+            element "termref"
+            mixed_content
+            map_attribute "base", to: :base
+            map_attribute "target", to: :target
+            map_content to: :text
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/document/components/inline/title_with_annotation_element.rb
+++ b/lib/metanorma/document/components/inline/title_with_annotation_element.rb
@@ -6,6 +6,7 @@ module Metanorma
       module Inline
         class TitleWithAnnotationElement < Lutaml::Model::Serializable
           attribute :id, :string
+          attribute :anchor, :string
           attribute :semx_id, :string
           attribute :text, :string, collection: true
           attribute :fmt_annotation_end, FmtAnnotationBodyElement
@@ -31,6 +32,7 @@ module Metanorma
             element "title"
             mixed_content
             map_attribute "id", to: :id
+            map_attribute "anchor", to: :anchor
             map_attribute "semx-id", to: :semx_id
             map_content to: :text
             map_element "em", to: :em

--- a/lib/metanorma/document/components/inline/vocabulary.rb
+++ b/lib/metanorma/document/components/inline/vocabulary.rb
@@ -110,6 +110,18 @@ module Metanorma
               base.attribute :input,
                              Metanorma::Document::Elements::Input,
                              collection: true
+              base.attribute :passthrough,
+                             Metanorma::Document::Components::Blocks::Passthrough,
+                             collection: true
+              base.attribute :date,
+                             Metanorma::Document::Components::Inline::DateElement,
+                             collection: true
+              base.attribute :fmt_date,
+                             Metanorma::Document::Components::Inline::FmtDateElement,
+                             collection: true
+              base.attribute :erefstack,
+                             Metanorma::Document::Components::Inline::ErefStack,
+                             collection: true
             end
 
             def declare_rendered_display_attributes_on(base)
@@ -168,6 +180,10 @@ module Metanorma
               "add" => :add,
               "del" => :del,
               "input" => :input,
+              "passthrough" => :passthrough,
+              "date" => :date,
+              "fmt-date" => :fmt_date,
+              "erefstack" => :erefstack,
               "fmt-stem" => :fmt_stem,
               "fmt-concept" => :fmt_concept,
               "fmt-fn-label" => :fmt_fn_label,

--- a/lib/metanorma/document/components/lists/dd_element.rb
+++ b/lib/metanorma/document/components/lists/dd_element.rb
@@ -7,6 +7,7 @@ module Metanorma
         # Definition description element, containing paragraphs.
         class DdElement < Lutaml::Model::Serializable
           attribute :id, :string
+          attribute :anchor, :string
           attribute :semx_id, :string
           attribute :p, "Metanorma::Document::Components::Paragraphs::ParagraphBlock",
                     collection: true
@@ -36,6 +37,7 @@ module Metanorma
           xml do
             element "dd"
             map_attribute "id", to: :id
+            map_attribute "anchor", to: :anchor
             map_attribute "semx-id", to: :semx_id
             map_element "p", to: :p
             map_element "ul", to: :ul

--- a/lib/metanorma/document/components/lists/definition.rb
+++ b/lib/metanorma/document/components/lists/definition.rb
@@ -6,6 +6,7 @@ module Metanorma
       module Lists
         # Definition used to constitute a definition list.
         class Definition < Lutaml::Model::Serializable
+          attribute :anchor, :string
           attribute :item, "Metanorma::Document::Components::TextElements::TextElement",
                     collection: true
           attribute :definition,
@@ -18,6 +19,7 @@ module Metanorma
 
           xml do
             element "dd"
+            map_attribute "anchor", to: :anchor
             map_element "item", to: :item
             map_element "definition", to: :definition
             map_element "p", to: :p

--- a/lib/metanorma/document/components/paragraphs/paragraph_block.rb
+++ b/lib/metanorma/document/components/paragraphs/paragraph_block.rb
@@ -83,6 +83,14 @@ module Metanorma
                     collection: true
           attribute :input, Metanorma::Document::Elements::Input,
                     collection: true
+          attribute :passthrough, Metanorma::Document::Components::Blocks::Passthrough,
+                    collection: true
+          attribute :date, Metanorma::Document::Components::Inline::DateElement,
+                    collection: true
+          attribute :fmt_date, Metanorma::Document::Components::Inline::FmtDateElement,
+                    collection: true
+          attribute :erefstack, Metanorma::Document::Components::Inline::ErefStack,
+                    collection: true
 
           # JSON serialization attributes
           attribute :json_type, :string
@@ -141,6 +149,10 @@ module Metanorma
             map_element "add", to: :add
             map_element "del", to: :del
             map_element "input", to: :input
+            map_element "passthrough", to: :passthrough
+            map_element "date", to: :date
+            map_element "fmt-date", to: :fmt_date
+            map_element "erefstack", to: :erefstack
           end
 
           def json_content

--- a/lib/metanorma/document/components/reference_elements/citation.rb
+++ b/lib/metanorma/document/components/reference_elements/citation.rb
@@ -16,6 +16,8 @@ module Metanorma
                     collection: true
           attribute :locality_stack, Metanorma::Document::Relaton::LocalityStack,
                     collection: true
+          attribute :locality, Metanorma::Document::Relaton::BibItemLocality,
+                    collection: true
           attribute :bib_item, Metanorma::Document::Components::BibData::BibliographicItem
           attribute :display_text, "Metanorma::Document::Components::Inline::DisplayTextElement"
 
@@ -28,6 +30,7 @@ module Metanorma
             map_element "bib-locality", to: :bib_locality
             map_element "bib-locality-stack", to: :bib_locality_stack
             map_element "localityStack", to: :locality_stack
+            map_element "locality", to: :locality
             map_element "bib-item", to: :bib_item
             map_element "display-text", to: :display_text
           end

--- a/lib/metanorma/document/components/tables/table_cell.rb
+++ b/lib/metanorma/document/components/tables/table_cell.rb
@@ -7,6 +7,7 @@ module Metanorma
         # Base class for table cells with common attributes and mixed content.
         class TableCell < Lutaml::Model::Serializable
           attribute :id, :string
+          attribute :anchor, :string
           attribute :colspan, :integer
           attribute :rowspan, :integer
           attribute :align, :string
@@ -94,6 +95,7 @@ module Metanorma
           xml do
             mixed_content
             map_attribute "id", to: :id
+            map_attribute "anchor", to: :anchor
             map_attribute "colspan", to: :colspan
             map_attribute "rowspan", to: :rowspan
             map_attribute "align", to: :align

--- a/lib/metanorma/document/components/tables/text_table_row.rb
+++ b/lib/metanorma/document/components/tables/text_table_row.rb
@@ -7,6 +7,7 @@ module Metanorma
         # Sequence of cells to be displayed as a row in a table.
         class TextTableRow < Lutaml::Model::Serializable
           attribute :id, :string
+          attribute :anchor, :string
           attribute :semx_id, :string
           attribute :td, TextTableCell, collection: true
           attribute :th, HeaderTableCell, collection: true
@@ -14,6 +15,7 @@ module Metanorma
           xml do
             element "tr"
             map_attribute "id", to: :id
+            map_attribute "anchor", to: :anchor
             map_attribute "semx-id", to: :semx_id
             map_element "td", to: :td
             map_element "th", to: :th

--- a/lib/metanorma/ietf_document/metadata/ietf_bib_data_extension_type.rb
+++ b/lib/metanorma/ietf_document/metadata/ietf_bib_data_extension_type.rb
@@ -10,6 +10,9 @@ module Metanorma
         attribute :consensus, :string
         attribute :area, :string, collection: true
         attribute :submission_type, :string
+        attribute :sym_refs, :string
+        attribute :toc_include, :string
+        attribute :sort_refs, :string
         attribute :editorial_group, IetfEditorialGroup
         attribute :pi, PiSettings
 
@@ -21,6 +24,9 @@ module Metanorma
           map_element "consensus", to: :consensus
           map_element "area", to: :area
           map_element "submissionType", to: :submission_type
+          map_element "symRefs", to: :sym_refs
+          map_element "tocInclude", to: :toc_include
+          map_element "sortRefs", to: :sort_refs
           map_element "editorial-group", to: :editorial_group
           map_element "editorialgroup", to: :editorial_group
           map_element "pi", to: :pi

--- a/lib/metanorma/ietf_document/metadata/pi_settings.rb
+++ b/lib/metanorma/ietf_document/metadata/pi_settings.rb
@@ -5,6 +5,7 @@ module Metanorma
     module Metadata
       class PiSettings < Lutaml::Model::Serializable
         attribute :toc, :string
+        attribute :tocinclude, :string
         attribute :tocdepth, :string
         attribute :symrefs, :string
         attribute :sortrefs, :string
@@ -17,6 +18,7 @@ module Metanorma
         xml do
           element "pi"
           map_element "toc", to: :toc
+          map_element "tocinclude", to: :tocinclude
           map_element "tocdepth", to: :tocdepth
           map_element "symrefs", to: :symrefs
           map_element "sortrefs", to: :sortrefs

--- a/lib/metanorma/iso_document/terms/term_example.rb
+++ b/lib/metanorma/iso_document/terms/term_example.rb
@@ -4,36 +4,7 @@ module Metanorma
   module IsoDocument
     module Terms
       # Example within a term entry.
-      class TermExample < Lutaml::Model::Serializable
-        attribute :id, :string
-        attribute :semx_id, :string
-        attribute :autonum, :string
-        attribute :p, Metanorma::Document::Components::Paragraphs::ParagraphBlock,
-                  collection: true
-        attribute :ol, Metanorma::Document::Components::Lists::OrderedList,
-                  collection: true
-        attribute :ul, Metanorma::Document::Components::Lists::UnorderedList,
-                  collection: true
-        attribute :dl, Metanorma::Document::Components::Lists::DefinitionList
-        attribute :name, Metanorma::Document::Components::Inline::NameWithIdElement,
-                  collection: true
-        attribute :fmt_xref_label,
-                  Metanorma::Document::Components::Inline::FmtXrefLabelElement, collection: true
-        attribute :fmt_name, Metanorma::Document::Components::Inline::FmtNameElement
-
-        xml do
-          element "termexample"
-          map_attribute "id", to: :id
-          map_attribute "semx-id", to: :semx_id
-          map_attribute "autonum", to: :autonum, render_empty: true
-          map_element "name", to: :name
-          map_element "p", to: :p
-          map_element "ol", to: :ol
-          map_element "ul", to: :ul
-          map_element "dl", to: :dl
-          map_element "fmt-xref-label", to: :fmt_xref_label
-          map_element "fmt-name", to: :fmt_name
-        end
+      class TermExample < Metanorma::StandardDocument::Terms::TermExample
       end
     end
   end

--- a/lib/metanorma/iso_document/terms/term_note.rb
+++ b/lib/metanorma/iso_document/terms/term_note.rb
@@ -4,38 +4,7 @@ module Metanorma
   module IsoDocument
     module Terms
       # Note to a term entry.
-      class TermNote < Lutaml::Model::Serializable
-        attribute :id, :string
-        attribute :anchor, :string
-        attribute :semx_id, :string
-        attribute :autonum, :string
-        attribute :p, Metanorma::Document::Components::Paragraphs::ParagraphBlock,
-                  collection: true
-        attribute :ol, Metanorma::Document::Components::Lists::OrderedList,
-                  collection: true
-        attribute :ul, Metanorma::Document::Components::Lists::UnorderedList,
-                  collection: true
-        attribute :dl, Metanorma::Document::Components::Lists::DefinitionList
-        attribute :name, Metanorma::Document::Components::Inline::NameWithIdElement,
-                  collection: true
-        attribute :fmt_xref_label,
-                  Metanorma::Document::Components::Inline::FmtXrefLabelElement, collection: true
-        attribute :fmt_name, Metanorma::Document::Components::Inline::FmtNameElement
-
-        xml do
-          element "termnote"
-          map_attribute "id", to: :id
-          map_attribute "anchor", to: :anchor
-          map_attribute "semx-id", to: :semx_id
-          map_attribute "autonum", to: :autonum, render_empty: true
-          map_element "name", to: :name
-          map_element "p", to: :p
-          map_element "ol", to: :ol
-          map_element "ul", to: :ul
-          map_element "dl", to: :dl
-          map_element "fmt-xref-label", to: :fmt_xref_label
-          map_element "fmt-name", to: :fmt_name
-        end
+      class TermNote < Metanorma::StandardDocument::Terms::TermNote
       end
     end
   end

--- a/lib/metanorma/standard_document/annotation_container.rb
+++ b/lib/metanorma/standard_document/annotation_container.rb
@@ -5,6 +5,7 @@ module Metanorma
     class AnnotationContainer < Lutaml::Model::Serializable
       class Annotation < Lutaml::Model::Serializable
         attribute :id, :string
+        attribute :anchor, :string
         attribute :reviewer, :string
         attribute :from, :string
         attribute :to, :string
@@ -18,6 +19,7 @@ module Metanorma
         xml do
           element "annotation"
           map_attribute "id", to: :id
+          map_attribute "anchor", to: :anchor
           map_attribute "reviewer", to: :reviewer
           map_attribute "from", to: :from
           map_attribute "to", to: :to

--- a/lib/metanorma/standard_document/block_attributes.rb
+++ b/lib/metanorma/standard_document/block_attributes.rb
@@ -222,7 +222,8 @@ module Metanorma
 
       # Common XML element/attribute mappings for the sections container.
       def self.apply_sections_elements(mapping)
-        mapping.map_element "clause",         to: :clause
+        mapping.map_element "clause", to: :clause
+        mapping.map_element "introduction", to: :introduction
         mapping.map_element "terms",          to: :terms
         mapping.map_element "definitions",    to: :definitions
         mapping.map_element "floating-title", to: :floating_title

--- a/lib/metanorma/standard_document/sections/sections.rb
+++ b/lib/metanorma/standard_document/sections/sections.rb
@@ -10,6 +10,8 @@ module Metanorma
       #   }
       class Sections < Lutaml::Model::Serializable
         attribute :clause, ClauseSection, collection: true
+        attribute :introduction,
+                  Metanorma::StandardDocument::Sections::Introduction
         attribute :terms,
                   Metanorma::StandardDocument::Sections::TermsSection,
                   collection: true

--- a/lib/metanorma/standard_document/terms.rb
+++ b/lib/metanorma/standard_document/terms.rb
@@ -9,6 +9,7 @@ module Metanorma
       autoload :Designation, "#{__dir__}/terms/designation"
       autoload :ExpressionDesignation, "#{__dir__}/terms/expression_designation"
       autoload :ExpressionType, "#{__dir__}/terms/expression_type"
+      autoload :FmtDeprecates, "#{__dir__}/terms/fmt_deprecates"
       autoload :GrammarGender, "#{__dir__}/terms/grammar_gender"
       autoload :GrammarInfo, "#{__dir__}/terms/grammar_info"
       autoload :GraphicalSymbolDesignation,
@@ -23,7 +24,9 @@ module Metanorma
       autoload :TermCollection, "#{__dir__}/terms/term_collection"
       autoload :TermDefinition, "#{__dir__}/terms/term_definition"
       autoload :TermExpression, "#{__dir__}/terms/term_expression"
+      autoload :TermExample, "#{__dir__}/terms/term_example"
       autoload :TermNameElement, "#{__dir__}/terms/term_name_element"
+      autoload :TermNote, "#{__dir__}/terms/term_note"
       autoload :TermSource, "#{__dir__}/terms/term_source"
       autoload :TermSourceStatus, "#{__dir__}/terms/term_source_status"
       autoload :TermSourceType, "#{__dir__}/terms/term_source_type"

--- a/lib/metanorma/standard_document/terms/concept.rb
+++ b/lib/metanorma/standard_document/terms/concept.rb
@@ -7,6 +7,7 @@ module Metanorma
       # That concept may be defined as a term within the current document, or it may
       # be defined externally.
       class Concept < Lutaml::Model::Serializable
+        attribute :bold, :boolean
         attribute :ital, :boolean
         attribute :ref, :boolean
         attribute :linkmention, :boolean
@@ -15,7 +16,9 @@ module Metanorma
         attribute :renderterm, :string
         attribute :xref, Metanorma::Document::Components::ReferenceElements::ReferenceToIdElement
         attribute :eref, Metanorma::Document::Components::ReferenceElements::ReferenceToCitationElement
-        attribute :termref, Metanorma::StandardDocument::Refs::ReferenceToTermbase
+        attribute :erefstack, Metanorma::Document::Components::Inline::ErefStack
+        attribute :termref, Metanorma::Document::Components::Inline::TermrefElement
+        attribute :errormsg, Metanorma::Document::Components::Inline::ErrorMessage
 
         attribute :semx_id, :string
         attribute :original_id, :string
@@ -23,6 +26,7 @@ module Metanorma
         xml do
           element "concept"
           mixed_content
+          map_attribute "bold", to: :bold
           map_attribute "ital", to: :ital
           map_attribute "ref", to: :ref
           map_attribute "linkmention", to: :linkmention
@@ -31,7 +35,9 @@ module Metanorma
           map_element "renderterm", to: :renderterm
           map_element "xref", to: :xref
           map_element "eref", to: :eref
+          map_element "erefstack", to: :erefstack
           map_element "termref", to: :termref
+          map_element "errormsg", to: :errormsg
 
           map_attribute "semx-id", to: :semx_id
           map_attribute "original-id", to: :original_id

--- a/lib/metanorma/standard_document/terms/fmt_deprecates.rb
+++ b/lib/metanorma/standard_document/terms/fmt_deprecates.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module StandardDocument
+    module Terms
+      # Presentation-layer rendering of a deprecated designation:
+      # the formatted deprecation notice emitted alongside the semantic
+      # `deprecates` designation.
+      class FmtDeprecates < Lutaml::Model::Serializable
+        attribute :p, Metanorma::Document::Components::Paragraphs::ParagraphBlock,
+                  collection: true
+
+        xml do
+          element "fmt-deprecates"
+          map_element "p", to: :p
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/standard_document/terms/related_term.rb
+++ b/lib/metanorma/standard_document/terms/related_term.rb
@@ -9,7 +9,8 @@ module Metanorma
         attribute :preferred, Metanorma::StandardDocument::Terms::Designation
         attribute :xref, Metanorma::Document::Components::Inline::XrefElement
         attribute :eref, Metanorma::Document::Components::Inline::ErefElement
-        attribute :termref, Metanorma::StandardDocument::Refs::ReferenceToTermbase
+        attribute :termref, Metanorma::Document::Components::Inline::TermrefElement
+        attribute :errormsg, Metanorma::Document::Components::Inline::ErrorMessage
 
         attribute :semx_id, :string
         attribute :original_id, :string
@@ -21,6 +22,7 @@ module Metanorma
           map_element "xref", to: :xref
           map_element "eref", to: :eref
           map_element "termref", to: :termref
+          map_element "errormsg", to: :errormsg
 
           map_attribute "semx-id", to: :semx_id
           map_attribute "original-id", to: :original_id

--- a/lib/metanorma/standard_document/terms/term.rb
+++ b/lib/metanorma/standard_document/terms/term.rb
@@ -14,6 +14,7 @@ module Metanorma
         attribute :tag, :string
         attribute :multilingual_rendering, :string
         attribute :id, :string
+        attribute :anchor, :string
         attribute :preferred, Metanorma::StandardDocument::Terms::Designation,
                   collection: true
         attribute :admitted, Metanorma::StandardDocument::Terms::Designation,
@@ -22,16 +23,18 @@ module Metanorma
                   collection: true
         attribute :deprecates, Metanorma::StandardDocument::Terms::Designation,
                   collection: true
+        attribute :fmt_deprecates,
+                  Metanorma::StandardDocument::Terms::FmtDeprecates
         attribute :domain, Metanorma::Document::Components::DataTypes::LocalizedString
         attribute :subject, Metanorma::Document::Components::DataTypes::LocalizedString
         attribute :usage_info,
                   Metanorma::Document::Components::Blocks::BasicBlock, collection: true
         attribute :definition, Metanorma::StandardDocument::Terms::TermDefinition,
                   collection: true
-        attribute :note,
-                  Metanorma::Document::Components::Paragraphs::ParagraphBlock, collection: true
-        attribute :example,
-                  Metanorma::Document::Components::Paragraphs::ParagraphBlock, collection: true
+        attribute :note, Metanorma::StandardDocument::Terms::TermNote,
+                  collection: true
+        attribute :example, Metanorma::StandardDocument::Terms::TermExample,
+                  collection: true
         attribute :source, Metanorma::StandardDocument::Terms::TermSource,
                   collection: true
 
@@ -45,10 +48,12 @@ module Metanorma
           map_attribute "tag", to: :tag
           map_attribute "multilingual-rendering", to: :multilingual_rendering
           map_attribute "id", to: :id
+          map_attribute "anchor", to: :anchor
           map_element "preferred", to: :preferred
           map_element "admitted", to: :admitted
           map_element "related", to: :related
           map_element "deprecates", to: :deprecates
+          map_element "fmt-deprecates", to: :fmt_deprecates
           map_element "domain", to: :domain
           map_element "subject", to: :subject
           map_element "usage-info", to: :usage_info

--- a/lib/metanorma/standard_document/terms/term_example.rb
+++ b/lib/metanorma/standard_document/terms/term_example.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module StandardDocument
+    module Terms
+      # Example within a term entry. Wraps block children (`p`, lists) and
+      # the presentation rendering channels (`fmt-name`, `fmt-xref-label`).
+      class TermExample < Lutaml::Model::Serializable
+        attribute :id, :string
+        attribute :anchor, :string
+        attribute :semx_id, :string
+        attribute :autonum, :string
+        attribute :p, Metanorma::Document::Components::Paragraphs::ParagraphBlock,
+                  collection: true
+        attribute :ol, Metanorma::Document::Components::Lists::OrderedList,
+                  collection: true
+        attribute :ul, Metanorma::Document::Components::Lists::UnorderedList,
+                  collection: true
+        attribute :dl, Metanorma::Document::Components::Lists::DefinitionList
+        attribute :name, Metanorma::Document::Components::Inline::NameWithIdElement,
+                  collection: true
+        attribute :fmt_xref_label,
+                  Metanorma::Document::Components::Inline::FmtXrefLabelElement, collection: true
+        attribute :fmt_name, Metanorma::Document::Components::Inline::FmtNameElement
+
+        xml do
+          element "termexample"
+          map_attribute "id", to: :id
+          map_attribute "anchor", to: :anchor
+          map_attribute "semx-id", to: :semx_id
+          map_attribute "autonum", to: :autonum, render_empty: true
+          map_element "name", to: :name
+          map_element "p", to: :p
+          map_element "ol", to: :ol
+          map_element "ul", to: :ul
+          map_element "dl", to: :dl
+          map_element "fmt-xref-label", to: :fmt_xref_label
+          map_element "fmt-name", to: :fmt_name
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/standard_document/terms/term_name_element.rb
+++ b/lib/metanorma/standard_document/terms/term_name_element.rb
@@ -20,6 +20,7 @@ module Metanorma
           map_attribute "semx-id", to: :semx_id
           map_attribute "lang", to: :lang
           mixed_content
+          map_content to: :text
           Metanorma::Document::Components::Inline::Vocabulary::VocabularyXmlMapping
             .apply_inline_mappings(self)
         end

--- a/lib/metanorma/standard_document/terms/term_note.rb
+++ b/lib/metanorma/standard_document/terms/term_note.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module StandardDocument
+    module Terms
+      # Note to a term entry. Wraps block children (`p`, lists) and the
+      # presentation rendering channels (`fmt-name`, `fmt-xref-label`).
+      class TermNote < Lutaml::Model::Serializable
+        attribute :id, :string
+        attribute :anchor, :string
+        attribute :semx_id, :string
+        attribute :autonum, :string
+        attribute :p, Metanorma::Document::Components::Paragraphs::ParagraphBlock,
+                  collection: true
+        attribute :ol, Metanorma::Document::Components::Lists::OrderedList,
+                  collection: true
+        attribute :ul, Metanorma::Document::Components::Lists::UnorderedList,
+                  collection: true
+        attribute :dl, Metanorma::Document::Components::Lists::DefinitionList
+        attribute :name, Metanorma::Document::Components::Inline::NameWithIdElement,
+                  collection: true
+        attribute :fmt_xref_label,
+                  Metanorma::Document::Components::Inline::FmtXrefLabelElement, collection: true
+        attribute :fmt_name, Metanorma::Document::Components::Inline::FmtNameElement
+
+        xml do
+          element "termnote"
+          map_attribute "id", to: :id
+          map_attribute "anchor", to: :anchor
+          map_attribute "semx-id", to: :semx_id
+          map_attribute "autonum", to: :autonum, render_empty: true
+          map_element "name", to: :name
+          map_element "p", to: :p
+          map_element "ol", to: :ol
+          map_element "ul", to: :ul
+          map_element "dl", to: :dl
+          map_element "fmt-xref-label", to: :fmt_xref_label
+          map_element "fmt-name", to: :fmt_name
+        end
+      end
+    end
+  end
+end

--- a/spec/metanorma/document/components/blocks/requirement_model_spec.rb
+++ b/spec/metanorma/document/components/blocks/requirement_model_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require_relative "../../../../spec_helper"
+
+RSpec.describe Metanorma::Document::Components::Blocks::RequirementModel do
+  it "maps identifier, title and the presentation rendering channels" do
+    xml = <<~XML
+      <requirement id="_r1" model="default" obligation="requirement">
+        <fmt-name><span class="fmt-caption-label">Requirement 1</span></fmt-name>
+        <fmt-xref-label><span class="fmt-element-name">Requirement</span></fmt-xref-label>
+        <title>Accuracy of measurement</title>
+        <identifier>NO-ACC</identifier>
+        <subject>measuring system</subject>
+        <description><p>The system shall measure accurately.</p></description>
+        <specification><p>Specification content</p></specification>
+        <measurement-target><p>Measurement target content</p></measurement-target>
+        <verification><p>Verification content</p></verification>
+        <import><p>Imported requirement content</p></import>
+        <fmt-provision><p>Rendered provision body</p></fmt-provision>
+      </requirement>
+    XML
+
+    req = described_class.from_xml(xml)
+
+    expect(req.identifier).to eq("NO-ACC")
+    expect(req.title.value).to eq(["Accuracy of measurement"])
+    expect(req.fmt_name).to be_a(Metanorma::Document::Components::Inline::FmtNameElement)
+    expect(req.fmt_xref_label).to all(be_a(Metanorma::Document::Components::Inline::FmtXrefLabelElement))
+    expect(req.specification.first.p.first.text).to eq(["Specification content"])
+    expect(req.measurement_target.first.p.first.text).to eq(["Measurement target content"])
+    expect(req.verification.first.p.first.text).to eq(["Verification content"])
+    expect(req.import.first.p.first.text).to eq(["Imported requirement content"])
+    expect(req.fmt_provision.p.first.text).to eq(["Rendered provision body"])
+  end
+
+  it "keeps the mapping on the recommendation carrier" do
+    xml = <<~XML
+      <recommendation id="_rec1" model="default">
+        <identifier>REC-1</identifier>
+        <title>Follow the process</title>
+        <description><p>Do the thing.</p></description>
+        <fmt-provision><p>Rendered recommendation</p></fmt-provision>
+      </recommendation>
+    XML
+
+    rec = Metanorma::Document::Components::Blocks::RecommendationModel.from_xml(xml)
+
+    expect(rec.identifier).to eq("REC-1")
+    expect(rec.title.value).to eq(["Follow the process"])
+    expect(rec.fmt_provision.p.first.text).to eq(["Rendered recommendation"])
+  end
+
+  it "keeps the mapping on the permission carrier" do
+    xml = <<~XML
+      <permission id="_perm1" model="default">
+        <identifier>PERM-1</identifier>
+        <title>Allow the action</title>
+        <description><p>The action is allowed.</p></description>
+        <fmt-provision><p>Rendered permission</p></fmt-provision>
+      </permission>
+    XML
+
+    perm = Metanorma::Document::Components::Blocks::PermissionModel.from_xml(xml)
+
+    expect(perm.identifier).to eq("PERM-1")
+    expect(perm.title.value).to eq(["Allow the action"])
+    expect(perm.fmt_provision.p.first.text).to eq(["Rendered permission"])
+  end
+end

--- a/spec/metanorma/document/components/paragraphs/passthrough_spec.rb
+++ b/spec/metanorma/document/components/paragraphs/passthrough_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require_relative "../../../../spec_helper"
+
+RSpec.describe "passthrough mapping on paragraph and inline carriers" do
+  it "maps passthrough with its formats attribute on paragraphs" do
+    xml = <<~XML
+      <p>See <passthrough formats="html">HTML-only content</passthrough> for details.</p>
+    XML
+
+    para = Metanorma::Document::Components::Paragraphs::ParagraphBlock.from_xml(xml)
+
+    expect(para.passthrough.size).to eq(1)
+    expect(para.passthrough.first.formats).to eq("html")
+    expect(para.passthrough.first.content).to include("HTML-only")
+  end
+
+  it "maps passthrough on vocabulary-based inline carriers" do
+    xml = <<~XML
+      <span class="keep">before <passthrough formats="docx">inner</passthrough> after</span>
+    XML
+
+    span = Metanorma::Document::Components::Inline::SpanElement.from_xml(xml)
+
+    expect(span.passthrough.size).to eq(1)
+    expect(span.passthrough.first.formats).to eq("docx")
+    expect(span.passthrough.first.content).to eq("inner")
+  end
+
+  it "maps multiple passthrough elements in order-preserving collections" do
+    xml = <<~XML
+      <p><passthrough formats="html">one</passthrough> text <passthrough formats="pdf,tex">two</passthrough></p>
+    XML
+
+    para = Metanorma::Document::Components::Paragraphs::ParagraphBlock.from_xml(xml)
+
+    expect(para.passthrough.map(&:formats)).to eq(%w[html pdf,tex])
+    expect(para.passthrough.map(&:content)).to eq(%w[one two])
+  end
+end

--- a/spec/metanorma/document/components/reference_elements/citation_locality_spec.rb
+++ b/spec/metanorma/document/components/reference_elements/citation_locality_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require_relative "../../../../spec_helper"
+
+RSpec.describe "direct locality mapping on citation carriers" do
+  it "maps direct locality children on eref" do
+    xml = <<~XML
+      <eref bibitemid="ISO712" citeas="ISO 712">
+        <locality type="section"><referenceFrom>3.1</referenceFrom></locality>
+      </eref>
+    XML
+
+    eref = Metanorma::Document::Components::Inline::ErefElement.from_xml(xml)
+
+    expect(eref.bibitemid).to eq("ISO712")
+    expect(eref.locality.size).to eq(1)
+    expect(eref.locality.first.type).to eq("section")
+    expect(eref.locality.first.reference_from).to eq("3.1")
+  end
+
+  it "maps direct locality children on the origin Citation carrier" do
+    xml = <<~XML
+      <citation bibitemid="ISO712" citeas="ISO 712" type="inline">
+        <locality type="section"><referenceFrom>3.1</referenceFrom></locality>
+        <locality type="table"><referenceFrom>2</referenceFrom></locality>
+      </citation>
+    XML
+
+    citation = Metanorma::Document::Components::ReferenceElements::Citation.from_xml(xml)
+
+    expect(citation.locality.size).to eq(2)
+    expect(citation.locality.map(&:type)).to eq(%w[section table])
+    expect(citation.locality.map(&:reference_from)).to eq(%w[3.1 2])
+  end
+
+  it "keeps localityStack mapping intact alongside direct localities" do
+    xml = <<~XML
+      <eref bibitemid="ISO712" citeas="ISO 712">
+        <localityStack><locality type="clause"><referenceFrom>5</referenceFrom></locality></localityStack>
+        <locality type="section"><referenceFrom>3.1</referenceFrom></locality>
+      </eref>
+    XML
+
+    eref = Metanorma::Document::Components::Inline::ErefElement.from_xml(xml)
+
+    expect(eref.locality_stack.size).to eq(1)
+    expect(eref.locality.size).to eq(1)
+    expect(eref.locality.first.reference_from).to eq("3.1")
+  end
+end

--- a/spec/metanorma/document/components/ws5c_mapping_gaps_spec.rb
+++ b/spec/metanorma/document/components/ws5c_mapping_gaps_spec.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+require_relative "../../../spec_helper"
+
+RSpec.describe "WS5c mapping gaps (#44, #46)" do
+  describe "@anchor on xref target carriers" do
+    it "maps anchor on td/th/tr, fn, term, name, title, variant-title, dd, definition, image, annotation, pre, span" do
+      cases = {
+        Metanorma::Document::Components::Inline::FnElement => '<fn id="_fn1" anchor="fn-anchor"><p>note</p></fn>',
+        Metanorma::StandardDocument::Terms::Term => '<term id="_t1" anchor="term-anchor"><preferred><expression><name>x</name></expression></preferred></term>',
+        Metanorma::Document::Components::Inline::NameWithIdElement => '<name id="_n1" anchor="name-anchor">Figure 1</name>',
+        Metanorma::Document::Components::Inline::TitleWithAnnotationElement => '<title id="_ti1" anchor="title-anchor">Scope</title>',
+        Metanorma::Document::Components::Inline::VariantTitleElement => '<variant-title type="sub" anchor="vt-anchor">Alt</variant-title>',
+        Metanorma::Document::Components::Lists::DdElement => '<dd id="_dd1" anchor="dd-anchor"><p>desc</p></dd>',
+        Metanorma::Document::Components::IdElements::Image => '<image id="_im1" anchor="img-anchor" src="x.png"/>',
+        Metanorma::Document::Components::AncillaryBlocks::LiteralBlock => '<pre id="_pre1" anchor="pre-anchor">text</pre>',
+        Metanorma::Document::Components::Inline::SpanElement => '<span anchor="span-anchor">styled</span>',
+      }
+
+      cases.each do |klass, xml|
+        expect(klass.from_xml(xml).anchor).to(
+          eq(xml[/anchor="([^"]+)"/, 1]),
+          "expected @anchor to map on #{klass.name}",
+        )
+      end
+
+      row = Metanorma::Document::Components::Tables::TextTableRow.from_xml(
+        '<tr id="_tr1" anchor="tr-anchor"><td id="_td1" anchor="td-anchor">cell</td><th id="_th1" anchor="th-anchor">head</th></tr>',
+      )
+      expect(row.anchor).to eq("tr-anchor")
+      expect(row.td.first.anchor).to eq("td-anchor")
+      expect(row.th.first.anchor).to eq("th-anchor")
+
+      annotation = Metanorma::StandardDocument::AnnotationContainer::Annotation
+        .from_xml('<annotation id="_a1" anchor="ann-anchor" reviewer="RV"><p>comment</p></annotation>')
+      expect(annotation.anchor).to eq("ann-anchor")
+    end
+  end
+
+  describe "inline date and fmt-date" do
+    it "maps value/format and the rendered form in body content" do
+      xml = <<~XML
+        <p>Published <date value="2020-01-01" format="dd MMM yyyy"/> on <fmt-date><semx element="date" source="_d1">1 Jan 2020</semx></fmt-date>.</p>
+      XML
+
+      para = Metanorma::Document::Components::Paragraphs::ParagraphBlock.from_xml(xml)
+
+      expect(para.date.first.value).to eq("2020-01-01")
+      expect(para.date.first.format).to eq("dd MMM yyyy")
+      expect(para.fmt_date.first.semx.first.text).to eq(["1 Jan 2020"])
+    end
+  end
+
+  describe "bibitem display attributes" do
+    it "maps hidden and suppress_identifier" do
+      xml = <<~XML
+        <bibitem id="_b1" hidden="true" suppress_identifier="true">
+          <formattedref format="text/plain">Some Reference</formattedref>
+        </bibitem>
+      XML
+
+      bibitem = Metanorma::Document::Components::BibData::BibliographicItem.from_xml(xml)
+
+      expect(bibitem.hidden).to be(true)
+      expect(bibitem.suppress_identifier).to be(true)
+    end
+  end
+
+  describe "erefstack" do
+    it "maps the element and its connective eref children" do
+      xml = <<~XML
+        <erefstack id="_es1">
+          <eref bibitemid="R1" citeas="RFC 1" connective="to"/>
+          <eref bibitemid="R2" citeas="RFC 2" custom-connective="and"/>
+        </erefstack>
+      XML
+
+      stack = Metanorma::Document::Components::Inline::ErefStack.from_xml(xml)
+
+      expect(stack.id).to eq("_es1")
+      expect(stack.eref.size).to eq(2)
+      expect(stack.eref.first.connective).to eq("to")
+      expect(stack.eref.last.custom_connective).to eq("and")
+    end
+
+    it "maps erefstack in body content and as concept child" do
+      para = Metanorma::Document::Components::Paragraphs::ParagraphBlock.from_xml(
+        "<p>See <erefstack><eref bibitemid=\"R1\" citeas=\"RFC 1\"/></erefstack>.</p>",
+      )
+      concept = Metanorma::StandardDocument::Terms::Concept.from_xml(
+        "<concept ital='true'><refterm>widget</refterm><erefstack><eref bibitemid='R1' citeas='RFC 1'/></erefstack></concept>",
+      )
+
+      expect(para.erefstack.first.eref.first.bibitemid).to eq("R1")
+      expect(concept.erefstack.eref.first.bibitemid).to eq("R1")
+    end
+  end
+
+  describe "concept semantic carriers" do
+    it "maps bold/ital/ref/linkmention/linkref and termref children" do
+      xml = <<~XML
+        <concept bold="true" ital="true" ref="false" linkmention="true" linkref="true">
+          <refterm>widget</refterm>
+          <renderterm>widgets</renderterm>
+          <termref base="ISO-termbase" target="3.1">widget</termref>
+        </concept>
+      XML
+
+      concept = Metanorma::StandardDocument::Terms::Concept.from_xml(xml)
+
+      expect(concept.bold).to be(true)
+      expect(concept.ital).to be(true)
+      expect(concept.ref).to be(false)
+      expect(concept.linkmention).to be(true)
+      expect(concept.linkref).to be(true)
+      expect(concept.termref.base).to eq("ISO-termbase")
+      expect(concept.termref.target).to eq("3.1")
+      expect(concept.termref.text).to eq(["widget"])
+    end
+
+    it "maps the same carriers on the inline concept element" do
+      xml = <<~XML
+        <concept ital="true" ref="true" linkmention="false" linkref="false" bold="true">
+          <refterm>widget</refterm><renderterm>widgets</renderterm>
+          <eref bibitemid="ISO712" citeas="ISO 712"/>
+        </concept>
+      XML
+
+      concept = Metanorma::Document::Components::Inline::ConceptElement.from_xml(xml)
+
+      expect(concept.bold).to be(true)
+      expect(concept.ital).to be(true)
+      expect(concept.ref).to be(true)
+      expect(concept.eref.bibitemid).to eq("ISO712")
+    end
+  end
+
+  describe "errormsg" do
+    it "maps errormsg as concept final choice with pure-text content" do
+      xml = <<~XML
+        <concept ital="true"><refterm>widget</refterm><errormsg>Unresolved reference to <em>widget</em>!</errormsg></concept>
+      XML
+
+      concept = Metanorma::Document::Components::Inline::ConceptElement.from_xml(xml)
+
+      expect(concept.errormsg).to be_a(Metanorma::Document::Components::Inline::ErrorMessage)
+      expect(concept.errormsg.text).to include("Unresolved reference to ")
+      expect(concept.errormsg.em.size).to eq(1)
+    end
+
+    it "maps errormsg inside related" do
+      xml = <<~XML
+        <related type="contrast"><errormsg>no match found</errormsg></related>
+      XML
+
+      related = Metanorma::StandardDocument::Terms::RelatedTerm.from_xml(xml)
+
+      expect(related.errormsg.text).to eq(["no match found"])
+    end
+  end
+end

--- a/spec/metanorma/document/relaton/typed_note_spec.rb
+++ b/spec/metanorma/document/relaton/typed_note_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require_relative "../../../spec_helper"
+
+RSpec.describe Metanorma::Document::Relaton::TypedNote do
+  it "maps structured p children of a display note" do
+    xml = <<~XML
+      <note type="display">
+        <p id="_n1">The identification of this document is deliberate.</p>
+        <p>Second annotation paragraph.</p>
+      </note>
+    XML
+
+    note = described_class.from_xml(xml)
+
+    expect(note.type).to eq("display")
+    expect(note.p.size).to eq(2)
+    expect(note.p.first.text).to eq(["The identification of this document is deliberate."])
+    expect(note.p.last.text).to eq(["Second annotation paragraph."])
+  end
+
+  it "keeps plain-text notes reachable alongside structured ones" do
+    xml = <<~XML
+      <note type="display" format="text/plain">Plain text annotation.</note>
+    XML
+
+    note = described_class.from_xml(xml)
+
+    expect(note.format).to eq("text/plain")
+    expect(note.text).to eq(["Plain text annotation."])
+  end
+
+  it "parses structured display notes through a references-section bibitem" do
+    xml = <<~XML
+      <references id="_refs" normative="true">
+        <bibitem id="RFC2100">
+          <note type="display"><p id="_n1">The identification of this RFC is deliberate.</p></note>
+        </bibitem>
+      </references>
+    XML
+
+    section = Metanorma::StandardDocument::Sections::StandardReferencesSection.from_xml(xml)
+    note = section.references.first.note.first
+
+    expect(note).to be_a(described_class)
+    expect(note.p.first.text).to eq(["The identification of this RFC is deliberate."])
+  end
+end

--- a/spec/metanorma/ietf_document/metadata/rfc_attributes_spec.rb
+++ b/spec/metanorma/ietf_document/metadata/rfc_attributes_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require_relative "../../../spec_helper"
+
+RSpec.describe Metanorma::IetfDocument::Metadata::IetfBibDataExtensionType do
+  it "maps the camelCase rfc-attribute channel" do
+    xml = <<~XML
+      <ext>
+        <doctype>internet-draft</doctype>
+        <ipr>trust200902</ipr>
+        <symRefs>false</symRefs>
+        <tocInclude>false</tocInclude>
+        <sortRefs>true</sortRefs>
+        <pi><tocinclude>no</tocinclude><symrefs>false</symrefs></pi>
+      </ext>
+    XML
+
+    ext = described_class.from_xml(xml)
+
+    expect(ext.doctype).to eq("internet-draft")
+    expect(ext.sym_refs).to eq("false")
+    expect(ext.toc_include).to eq("false")
+    expect(ext.sort_refs).to eq("true")
+    expect(ext.pi.tocinclude).to eq("no")
+    expect(ext.pi.symrefs).to eq("false")
+  end
+
+  it "maps the legacy pi toc channel under both spellings" do
+    legacy = described_class.from_xml("<ext><pi><toc>no</toc></pi></ext>")
+    emitted = described_class.from_xml("<ext><pi><tocinclude>no</tocinclude></pi></ext>")
+
+    expect(legacy.pi.toc).to eq("no")
+    expect(emitted.pi.tocinclude).to eq("no")
+  end
+end

--- a/spec/metanorma/standard_document/sections_introduction_spec.rb
+++ b/spec/metanorma/standard_document/sections_introduction_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require_relative "../../spec_helper"
+
+RSpec.describe Metanorma::StandardDocument::Sections::Sections do
+  it "maps introduction inside the sections container" do
+    xml = <<~XML
+      <sections>
+        <introduction id="_intro" obligation="normative">
+          <title>Introduction</title>
+          <p>Body introduction paragraph.</p>
+        </introduction>
+        <clause id="_c1"><title>Scope</title><p>Scope paragraph.</p></clause>
+      </sections>
+    XML
+
+    sections = described_class.from_xml(xml)
+
+    expect(sections.introduction).to be_a(Metanorma::StandardDocument::Sections::Introduction)
+    expect(sections.introduction.id).to eq("_intro")
+    expect(sections.introduction.title.text).to eq(["Introduction"])
+    expect(sections.clause.size).to eq(1)
+  end
+
+  it "maps introduction for the IETF sections class" do
+    xml = <<~XML
+      <sections>
+        <introduction id="_intro"><title>Introduction</title><p>Introductory remarks.</p></introduction>
+      </sections>
+    XML
+
+    sections = Metanorma::IetfDocument::Sections::IetfSections.from_xml(xml)
+
+    expect(sections.introduction).to be_a(Metanorma::StandardDocument::Sections::Introduction)
+    expect(sections.introduction.id).to eq("_intro")
+  end
+end

--- a/spec/metanorma/standard_document/terms/term_content_spec.rb
+++ b/spec/metanorma/standard_document/terms/term_content_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require_relative "../../../spec_helper"
+
+RSpec.describe Metanorma::StandardDocument::Terms::Term do
+  it "maps termnote block children and rendering channels" do
+    xml = <<~XML
+      <term id="_t1">
+        <termnote id="_n1" autonum="1">
+          <fmt-name><span class="fmt-caption-label">Note 1 to entry</span></fmt-name>
+          <fmt-xref-label><span class="fmt-element-name">Note 1</span></fmt-xref-label>
+          <p>Note content.</p>
+          <ul><li>list item</li></ul>
+        </termnote>
+      </term>
+    XML
+
+    term = described_class.from_xml(xml)
+    note = term.note.first
+
+    expect(note).to be_a(Metanorma::StandardDocument::Terms::TermNote)
+    expect(note.id).to eq("_n1")
+    expect(note.autonum).to eq("1")
+    expect(note.fmt_name).to be_a(Metanorma::Document::Components::Inline::FmtNameElement)
+    expect(note.fmt_xref_label.size).to eq(1)
+    expect(note.p.first.text).to eq(["Note content."])
+    expect(note.ul.size).to eq(1)
+  end
+
+  it "maps termexample block children" do
+    xml = <<~XML
+      <term id="_t1">
+        <termexample id="_e1">
+          <fmt-name><span>EXAMPLE</span></fmt-name>
+          <p>Example content.</p>
+        </termexample>
+      </term>
+    XML
+
+    term = described_class.from_xml(xml)
+    example = term.example.first
+
+    expect(example).to be_a(Metanorma::StandardDocument::Terms::TermExample)
+    expect(example.p.first.text).to eq(["Example content."])
+    expect(example.fmt_name).to be_a(Metanorma::Document::Components::Inline::FmtNameElement)
+  end
+
+  it "exposes deprecates designation content and its rendered form" do
+    xml = <<~XML
+      <term id="_t1">
+        <preferred><expression><name>cargo rice</name></expression></preferred>
+        <deprecates id="_d1"><expression><name>cargo rice</name></expression></deprecates>
+        <fmt-deprecates><p>DEPRECATED: cargo rice</p></fmt-deprecates>
+      </term>
+    XML
+
+    term = described_class.from_xml(xml)
+
+    expect(term.deprecates.first.expression.name.first.text).to eq(["cargo rice"])
+    expect(term.fmt_deprecates.p.first.text).to eq(["DEPRECATED: cargo rice"])
+  end
+end


### PR DESCRIPTION
## Summary

Fixes every mapping gap reported against 0.5.1: the metanorma-ietf transformer QA battery (#37–#44) and the WS5c completeness audit (#46). All elements in these reports survived parsing into `element_order` but had no typed mapping, so they were silently dropped at the model boundary. Every fix is a typed lutaml-model `attribute` + `map_element`/`map_attribute` declaration — no Nokogiri, no hand-rolled serialization, matching the existing per-carrier conventions.

### #37 — RequirementModel
Maps `identifier`, `title` (FormattedString), `specification`, `measurement-target`, `verification`, `import` (new `Requirement*` containers shaped like `RequirementDescription`), `fmt-name`, `fmt-xref-label`, and `fmt-provision` (new `FmtProvision` rendered-block container) on requirement/recommendation/permission. The four components beyond the issue's explicit list appear in the issue's own `element_order` probe, so they are mapped too.

### #38 — direct locality on citation carriers
`map_element "locality"` (typed `Relaton::BibItemLocality`, collection) on `Inline::ErefElement` and `Components::ReferenceElements::Citation`, alongside the existing `localityStack` mapping. Section labels like "ISO 712, Section 3.1" are now derivable.

### #39 — passthrough on paragraph/inline carriers
`passthrough` (+ `formats`) on `ParagraphBlock` and on `Inline::Vocabulary` (covers span, eref, and every vocabulary-based inline carrier), reusing the existing `Blocks::Passthrough` class — identical to the references-section mapping as requested.

### #40 — bibliographic note `p` children
Verified already mapped on main via `TypedNote` (the 0.5.x adapter keeps `p` as typed `ParagraphBlock`s; probes confirm structured display notes parse through `StandardReferencesSection → bibitem → note`). Locked with a regression spec.

### #41 — introduction inside sections
`introduction` mapped in `SectionXmlMapping.apply_sections_elements` + `Introduction` attribute on the `Sections` container — covers the standard and IETF classes via the shared mapping helper.

### #42 — term entry content
- New shared `StandardDocument::Terms::TermNote` / `TermExample` (block children `p`/`ol`/`ul`/`dl` + `name` + `fmt-name`/`fmt-xref-label` + `anchor`); `Term#note`/`#example` retyped to them. ISO flavor classes now subclass the shared ones. The HTML renderer already dispatches on the `:p`-declaring shape, so rendering is unaffected (all html/iso roundtrip specs green).
- Root cause of "deprecates parses empty": `TermNameElement` never mapped content — added `map_content`, making designation name text reachable for preferred/admitted/deprecates.
- New `fmt-deprecates` mapping (`FmtDeprecates`, rendered deprecation notice).

### #43 — IETF rfc-attribute channel
`symRefs`/`tocInclude`/`sortRefs` on `IetfBibDataExtensionType`; `pi/tocinclude` on `PiSettings` as its own `tocinclude` attribute (kept separate from legacy `toc` because two element names mapping to one attribute silently drop the first in lutaml-model).

### #44 — errormsg
New `Inline::ErrorMessage` (vocabulary-based pure-text + `index-xref`), mapped on `Inline::ConceptElement` (final-choice branch), `StandardDocument::Terms::Concept`, and `RelatedTerm`.

### #46 — WS5c audit
1. `@anchor` on td/th (via `TableCell`), tr, fn, term, name, title, variant-title, dd, definition, image, annotation, pre, span.
2. termnote/termexample block children — same as #42.
3. Inline `date` (new `DateElement`: `value`/`format`/language/script per grammar) and `fmt-date` (new `FmtDateElement` with `RenderedDisplay`, mirroring `FmtNameElement`) in `ParagraphBlock` + `Vocabulary`.
4. `bibitem/@hidden` and `@suppress_identifier` on `Components::BibData::BibliographicItem`.
5. `erefstack` (new `ErefStack` with `eref` children; `connective`/`custom-connective` added to `ErefElement` per `erefTypeWithConnective`), mapped in body content (`ParagraphBlock` + `Vocabulary`) and as a `concept` child.
6. `concept` semantic carriers: `@bold`/`@ital`/`@ref`/`@linkmention`/`@linkref` + `eref`/`erefstack`/`errormsg` children on `Inline::ConceptElement`; `@bold` + `erefstack`/`errormsg` on `StandardDocument::Terms::Concept`; `RelatedTerm` gains `errormsg`. `termref` retyped to a grammar-correct `Inline::TermrefElement` (`base`/`target` + text) — the previous `ReferenceToTermbase` type did not map termref content.

## Test plan

- [x] New specs per area: `requirement_model_spec`, `citation_locality_spec`, `passthrough_spec`, `typed_note_spec`, `sections_introduction_spec`, `term_content_spec`, `rfc_attributes_spec`, `ws5c_mapping_gaps_spec` — all assert parse accessors populated from presentation-XML-shaped fragments
- [x] Full suite: 1811 examples, 0 failures (baseline on main also green)
- [x] `rubocop` clean on all changed files
- [x] Each mapping verified with a standalone parse probe reproducing the original issue's symptoms before and after the fix
- [ ] CI green

Fixes #37, fixes #38, fixes #39, fixes #40, fixes #41, fixes #42, fixes #43, fixes #44, fixes #46
