### PR TITLE
MKO: walk preface foreword/introduction sections (8 documents lost to 0 chunks)

### DIFF
--- a/lib/metanorma/mko/project.rb
+++ b/lib/metanorma/mko/project.rb
@@ -117,6 +117,11 @@ module Metanorma
         def walk_container(container)
           vals(container, :clause).each { |s| yield s }
           vals(container, :terms).each { |s| yield s }
+          # preface-shaped containers declare :foreword/:introduction
+          # sections — OIML-CS admin documents keep their whole body
+          # there (semantic XML serializes an empty <sections>)
+          vals(container, :foreword).each { |s| yield s }
+          vals(container, :introduction).each { |s| yield s }
         end
 
         # Term entries: the iso tree declares them as :term with nested


### PR DESCRIPTION
`walk_container` yielded only `clause`/`terms` children — but preface-shaped containers declare their content as `:foreword`/`::introduction` sections. OIML-CS administrative documents (OD/PD series in mn-samples-oiml) serialize their **entire body** inside `<preface>` (the `<sections>` element is empty), so the MKO walk emitted 1 near-empty unit and the consumer indexed **0 chunks** for 8 documents while the HTML path had content for all of them.

Fix: yield `:foreword`/`:introduction` when the container declares them — attribute-driven like the rest of the walk, zero flavor knowledge.

Validated end-to-end on the full 36-document mn-samples-oiml corpus (re-export + consumer ingest): the 8 affected documents go from 0 chunks to 15–113 chunks each (e.g. OD-01: 0 → 108; PD-03: 0 → 73); corpus total 2,551 → 3,009 chunks; all other documents unchanged ±1 (their foreword/introduction units now also land).

Stacked on `feat/model-validation-l1-declarations` (the MKO stack) — happy to retarget if you prefer landing it separately.
