### PR TITLE
MKO: parsed identity fields + cite_as on units (#50 follow-ups 1-2)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -397,6 +397,27 @@ Metanorma::Mko.export(xml_or_model, to: dir, presentation_xml: nil, zip: false)
 #    edges.jsonl, bibdata.json, bibliography.jsonl, identifiers.json,
 #    glossary.json
 
+Collections export as document families — every member document as
+its own bundle plus one small collection bundle (collection.json and
+the doc:<member> part_of doc:<family> membership edges):
+
+[source,ruby]
+Metanorma::Mko::Collection.export("collection.yml", to: dir)
+
+Figure bytes are emitted as hash-addressed, manifest-verified bundle
+assets (data URIs from the model, or `assets_from:` paths). Language
+editions align by stable anchors:
+
+[source,ruby]
+Metanorma::Mko::Alignment.export(bundle_en, bundle_fr)
+# => alignment.jsonl of variant_of unit edges
+
+The wire contract ships as generated JSON Schema (the schema classes
+are the single source of truth):
+
+[source,ruby]
+Metanorma::Mko.json_schemas # => { "unit" => …, "collection" => …, "excerpt" => … }
+
 The bundle carries: typed units (clause, term, table, figure, formula,
 note, example, sourcecode, requirement, reference) with typed payloads;
 the edge graph (part_of containment, cites from reference and term units,

--- a/lib/metanorma/document/native_models.rb
+++ b/lib/metanorma/document/native_models.rb
@@ -123,6 +123,31 @@ module Metanorma
           nil
         end
 
+        # Parsed identity [series, number, part] via the native pubid
+        # parse — the single identity parser. OIML's series letter
+        # lives in the pubid type (recommendation → R, document → D,
+        # basic publication → B, guide → G, expert report → E,
+        # vocabulary → V); publishers without a series letter (ISO,
+        # IEC) yield nil series. Returns nil when no flavor covers the
+        # identifier — callers fall back, never guess.
+        OIML_SERIES = {
+          "recommendation" => "R", "document" => "D",
+          "basic-publication" => "B", "basic_publication" => "B",
+          "guide" => "G", "expert-report" => "E", "expert_report" => "E",
+          "vocabulary" => "V",
+        }.freeze
+
+        def pubid_identity(text)
+          pubid = parse_pubid(text)
+          return nil unless pubid
+
+          native = JSON.parse(pubid.to_json)
+          series = if native["_type"].to_s.start_with?("pubid:oiml:")
+                     OIML_SERIES[native["_type"].split(":").last]
+                   end
+          [series, native["number"]&.to_s, native["part"]&.to_s]
+        end
+
         # Formula as a native Plurimath::Math::Formula. Plurimath is the
         # Metanorma math ecosystem: parse from the stem's AsciiMath, or
         # from its MathML (the mml model's own XML serialization) when

--- a/lib/metanorma/document/native_models.rb
+++ b/lib/metanorma/document/native_models.rb
@@ -150,9 +150,12 @@ module Metanorma
 
         # -- publisher → pubid flavor --------------------------------
 
+        # "OIML" engages the day the flavor ships (pubid/pubid#342);
+        # until then Pubid::Oiml is undefined and parses nil.
         PUBID_FLAVORS = {
           "ISO" => :Iso, "IEC" => :Iec, "ITU" => :Itu, "BSI" => :Bsi,
-          "BS" => :Bsi, "OGC" => :Ogc, "NIST" => :Nist, "IEEE" => :Ieee
+          "BS" => :Bsi, "OGC" => :Ogc, "NIST" => :Nist, "IEEE" => :Ieee,
+          "OIML" => :Oiml
         }.freeze
 
         def parse_pubid(text)

--- a/lib/metanorma/mko.rb
+++ b/lib/metanorma/mko.rb
@@ -17,6 +17,8 @@ module Metanorma
     autoload :Writer, "metanorma/mko/writer"
     autoload :Exporter, "metanorma/mko/exporter"
     autoload :Assets, "metanorma/mko/assets"
+    autoload :Bundle, "metanorma/mko/bundle"
+    autoload :Collection, "metanorma/mko/collection"
 
     SCHEMA = "metanorma-mko"
     SCHEMA_VERSION = "1.0.0"
@@ -61,7 +63,7 @@ module Metanorma
                        else presentation_xml
                        end
         projection = Project.call(model, presentation: presentation,
-                                  assets: Assets.new(source_dir: assets_from))
+                                         assets: Assets.new(source_dir: assets_from))
         Writer.write(projection, to: to, zip: zip)
       end
 
@@ -77,6 +79,13 @@ module Metanorma
       # The published wire contract, generated from the schema
       # classes: name => JSON Schema (draft 2020-12). MN 116 ships
       # these alongside the spec text.
+      # Canonical short-id derivation (one rule, used by documents and
+      # collections alike).
+      def slug(canonical)
+        canonical.to_s.tr(" ", "-").gsub(/[^A-Za-z0-9.-]/, "")
+          .squeeze("-").downcase
+      end
+
       def json_schemas
         Schema::JsonSchema.all
       end

--- a/lib/metanorma/mko.rb
+++ b/lib/metanorma/mko.rb
@@ -19,6 +19,7 @@ module Metanorma
     autoload :Assets, "metanorma/mko/assets"
     autoload :Bundle, "metanorma/mko/bundle"
     autoload :Collection, "metanorma/mko/collection"
+    autoload :Alignment, "metanorma/mko/alignment"
 
     SCHEMA = "metanorma-mko"
     SCHEMA_VERSION = "1.0.0"

--- a/lib/metanorma/mko/alignment.rb
+++ b/lib/metanorma/mko/alignment.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "json"
+
+module Metanorma
+  module Mko
+    # Interlingual alignment (MN 116 §stability, P2): units across
+    # language editions of the same document are the same knowledge
+    # object when their anchors match — Metanorma translations carry
+    # the semantic anchors. Emits variant_of unit edges binding the
+    # editions: parallel corpora, cross-language retrieval with
+    # source-language provenance, and consistency diffs between
+    # translations.
+    module Alignment
+      class << self
+        # Align two bundles of the same document (different language
+        # editions) by stable unit anchor. Returns [Schema::Edge] with
+        # kind variant_of; content-hash anchors (h-…) and unmatched
+        # units are simply not aligned — never guessed.
+        def align(bundle_a, bundle_b)
+          a = units_by_anchor(bundle_a)
+          b = units_by_anchor(bundle_b)
+          a.keys.intersection(b.keys).filter_map do |anchor|
+            next if anchor.to_s.empty? || anchor.start_with?("h-")
+
+            Schema::Edge.new(from: a[anchor], to: b[anchor],
+                              kind: "variant_of")
+          end
+        end
+
+        # Write alignment.jsonl into bundle_a's directory; returns the
+        # path. The alignment is a derived artifact — regeneration
+        # replaces it.
+        def export(bundle_a, bundle_b)
+          edges = align(bundle_a, bundle_b)
+          path = File.join(bundle_a, "alignment.jsonl")
+          File.write(path, edges.map(&:to_json).join("\n") + "\n")
+          path
+        end
+
+        private
+
+        def units_by_anchor(bundle)
+          file = File.join(bundle, "units.jsonl")
+          File.readlines(file).each_with_object({}) do |line, h|
+            unit = JSON.parse(line)
+            h[unit["anchor"]] = unit["id"]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/mko/bundle.rb
+++ b/lib/metanorma/mko/bundle.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Mko
+    # The on-disk bundle writer: one place that knows the file layout,
+    # the manifest bookkeeping, and the hash verification inputs. The
+    # projection Writer and the collection exporter both compose it —
+    # bundle mechanics are never duplicated.
+    class Bundle
+      attr_reader :dir
+
+      def self.open(short, to)
+        new(File.expand_path(File.join(to, "#{short}.mko")))
+      end
+
+      def initialize(dir)
+        @dir = dir
+        @manifest = Schema::Manifest.new(
+          schema: SCHEMA, schema_version: SCHEMA_VERSION,
+          generated: Schema::Generated.new(
+            tool: "metanorma-document", schema_version: SCHEMA_VERSION,
+          ),
+          components: []
+        )
+        FileUtils.rm_rf(dir)
+        FileUtils.mkdir_p(dir)
+      end
+
+      def add_json(name, file, object)
+        path = File.join(dir, file)
+        File.write(path, JSON.pretty_generate(JSON.parse(object.to_json)))
+        component(name: name, file: file, media_type: "application/json")
+      end
+
+      # Line-oriented component; the block serializes each item
+      # (framework to_json by default).
+      def add_lines(name, file, items, &serializer)
+        serializer ||= lambda(&:to_json)
+        path = File.join(dir, file)
+        File.write(path, "#{items.map(&serializer).join("\n")}\n")
+        component(name: name, file: file, media_type: "application/jsonl",
+                  count: items.size)
+      end
+
+      def add_asset(entry)
+        path = File.join(dir, entry.name)
+        FileUtils.mkdir_p(File.dirname(path))
+        File.binwrite(path, entry.data)
+        component(name: entry.name, file: entry.name,
+                  media_type: entry.media_type, count: 1)
+      end
+
+      def flavor=(flavor)
+        @manifest.generated.flavor = flavor
+      end
+
+      def source_file=(source)
+        @manifest.source_file = source
+      end
+
+      def write_manifest
+        @manifest.generated.timestamp = Time.now.utc.iso8601
+        File.write(File.join(dir, "manifest.json"),
+                   JSON.pretty_generate(JSON.parse(@manifest.to_json)))
+        dir
+      end
+
+      def zip!
+        require "zip"
+        zip_path = "#{dir}.zip"
+        Zip::File.open(zip_path, Zip::File::CREATE) do |zipfile|
+          Dir[File.join(dir, "**", "*")].each do |f|
+            next if File.directory?(f)
+
+            zipfile.add(f.sub("#{dir}/", ""), f)
+          end
+        end
+        zip_path
+      end
+
+      private
+
+      def component(name:, file:, media_type:, count: nil)
+        @manifest.components << Schema::ManifestComponent.new(
+          name: name, file: file, media_type: media_type,
+          count: count, hash: "sha256:#{Digest::SHA256.file(File.join(dir, file)).hexdigest}"
+        )
+      end
+    end
+  end
+end

--- a/lib/metanorma/mko/collection.rb
+++ b/lib/metanorma/mko/collection.rb
@@ -1,0 +1,165 @@
+# frozen_string_literal: true
+
+require "yaml"
+
+module Metanorma
+  module Mko
+    # Collection export (MN 116 §collections): a metanorma
+    # collection.yml declares a document family (OIML R 60 parts,
+    # amendments, R 129/138/144). Every member document exports as its
+    # own bundle (the document bundle is the unit of truth); the
+    # collection adds one small bundle with the membership contract:
+    # collection.json and the cross-document part_of edges binding the
+    # members to the family. Member identity comes from each member's
+    # exported document.json — the collection yml's identifiers are
+    # reference labels only.
+    class Collection
+      Member = Struct.new(:fileref, :xml_path, :identifier,
+                          :bundle_path, :skipped, keyword_init: true)
+
+      class Result
+        attr_reader :collection_bundle, :members
+
+        def initialize(collection_bundle:, members:)
+          @collection_bundle = collection_bundle
+          @members = members
+        end
+
+        def skipped
+          members.select(&:skipped)
+        end
+      end
+
+      class << self
+        def export(yml, to:, assets_from: nil, zip: false)
+          new(yml, to: to, assets_from: assets_from, zip: zip).export
+        end
+      end
+
+      def initialize(yml, to:, assets_from: nil, zip: false)
+        @yml = if yml.is_a?(Hash)
+                 yml
+               elsif File.exist?(yml.to_s)
+                 YAML.safe_load_file(yml)
+               else
+                 YAML.safe_load(yml)
+               end
+        @base = File.exist?(yml.to_s) ? File.dirname(File.expand_path(yml.to_s)) : Dir.pwd
+        @to = to
+        @assets_from = assets_from
+        @zip = zip
+      end
+
+      def export
+        members = docrefs.filter_map do |ref|
+          member = resolve_member(ref)
+          next member if member.skipped
+
+          member.bundle_path = Mko.export(
+            File.read(member.xml_path), to: @to,
+                                        presentation_xml: presentation_for(member.xml_path),
+                                        assets_from: @assets_from || File.dirname(member.xml_path)
+          )
+          member
+        end
+        Result.new(collection_bundle: write_collection_bundle(members),
+                   members: members)
+      end
+
+      private
+
+      def docrefs
+        manifest = @yml["manifest"]
+        manifest = manifest.first if manifest.is_a?(Array)
+        Array(manifest.is_a?(Hash) ? manifest["docref"] : nil)
+      rescue StandardError
+        []
+      end
+
+      # The yml points members at .adoc sources; the compiled semantic
+      # XML sits beside them. Direct .xml filerefs work too.
+      def resolve_member(ref)
+        fileref = ref["fileref"].to_s
+        xml = fileref.end_with?(".xml") ? fileref : fileref.sub(/\.adoc$/, ".xml")
+        path = File.expand_path(xml, @base)
+        if File.file?(path)
+          Member.new(fileref: fileref, xml_path: path,
+                     identifier: ref["identifier"])
+        else
+          Member.new(fileref: fileref, xml_path: path,
+                     identifier: ref["identifier"], skipped: true)
+        end
+      end
+
+      def presentation_for(xml_path)
+        pres = xml_path.sub(/\.xml$/, ".presentation.xml")
+        File.file?(pres) ? File.read(pres) : nil
+      end
+
+      def canonical
+        docid = @yml.dig("bibdata", "docid")
+        docid = docid.first if docid.is_a?(Array)
+        docid.is_a?(Hash) ? docid["id"].to_s : docid.to_s
+      end
+
+      def title
+        t = @yml.dig("bibdata", "title")
+        t = t.first if t.is_a?(Array)
+        t.is_a?(Hash) ? t["content"].to_s : t.to_s
+      end
+
+      def collection_short
+        Mko.slug(canonical.empty? ? "collection" : canonical)
+      end
+
+      def member_data(member)
+        document = JSON.parse(File.read(File.join(member.bundle_path,
+                                                  "document.json")))
+        short = document.dig("ids", "short")
+        { "bundle" => "#{short}.mko",
+          "docidentifier" => document.dig("ids", "canonical"),
+          "identifier" => member.identifier,
+          "title" => Array(document["titles"]).first.to_h["text"],
+          "edition" => document["edition"] }
+      rescue StandardError
+        nil
+      end
+
+      def collection_member(member)
+        data = member_data(member) or return nil
+
+        Schema::CollectionMember.new(
+          bundle: data["bundle"], docidentifier: data["docidentifier"],
+          identifier: data["identifier"], title: data["title"],
+          edition: data["edition"]
+        )
+      end
+
+      def write_collection_bundle(members)
+        collection = Schema::Collection.new(
+          canonical: canonical, short: collection_short, title: title,
+          edition: @yml.dig("bibdata", "edition"),
+          members: members.filter_map { |m| collection_member(m) }
+        )
+        # A member whose identity collides with the family (e.g. a
+        # stale amendment bibdata — mn-samples-oiml#66) would emit a
+        # self-edge; skip those, they say nothing.
+        edges = collection.members.reject do |m|
+          m.docidentifier.to_s.empty? || m.docidentifier == collection.canonical
+        end.map do |m|
+          { "from" => "doc:#{m.docidentifier}",
+            "to" => "doc:#{collection.canonical}",
+            "kind" => "part_of" }
+        end
+        bundle = Bundle.open(collection_short, @to)
+        bundle.flavor = nil
+        bundle.add_json("collection", "collection.json", collection)
+        bundle.add_lines("edges", "edges.jsonl", edges) do |edge|
+          JSON.generate(edge)
+        end
+        bundle.write_manifest
+        @zip ? bundle.zip! : bundle.dir
+      end
+    end
+  end
+end

--- a/lib/metanorma/mko/project.rb
+++ b/lib/metanorma/mko/project.rb
@@ -13,7 +13,7 @@ module Metanorma
                     :bibliography, :identifiers, :assets, :flavor
 
         def initialize(document:, units:, edges:, glossary:, bibdata:,
-                       bibliography:, identifiers:, assets: [], flavor:)
+                       bibliography:, identifiers:, flavor:, assets: [])
           @document = document
           @units = units
           @edges = edges
@@ -199,6 +199,7 @@ module Metanorma
       def parse_identity(canonical)
         m = canonical.to_s.match(/\A(?:[A-Z][A-Za-z0-9&-]*\s+)?([A-Z])\s*(\d+)(?:-(\d+|[A-Za-z][A-Za-z0-9]*))?\b/)
         return [m[1], m[2], m[3]] if m
+
         []
       end
 
@@ -513,7 +514,7 @@ module Metanorma
         caption = Document::PlainText.call(val(figure, :name))
         img = val(figure, :image)
         uri = val(figure, :source) || val(img, :source) ||
-              val(img, :filename)
+          val(img, :filename)
         payload = Schema::FigurePayload.new(
           alt: val(figure, :alt) || val(img, :alt), uri: uri,
           asset: @assets&.attach(uri),

--- a/lib/metanorma/mko/project.rb
+++ b/lib/metanorma/mko/project.rb
@@ -39,6 +39,7 @@ module Metanorma
         @presentation = presentation
         @assets = assets
         @units = []
+        @units_by_id = {}
         @edges = []
         @numbers = {}
         @structure = []
@@ -192,6 +193,15 @@ module Metanorma
 
       # -- identity ----------------------------------------------------
 
+      # "OIML R 60-1" → ["R", "60", "1"]; "ISO 17301-1" likewise.
+      # Nil-safe: an unparseable canonical yields nils (fields absent in
+      # JSON), never a crash — unknown shapes stay visible, not fatal.
+      def parse_identity(canonical)
+        m = canonical.to_s.match(/\A(?:[A-Z][A-Za-z0-9&-]*\s+)?([A-Z])\s*(\d+)(?:-(\d+|[A-Za-z][A-Za-z0-9]*))?\b/)
+        return [m[1], m[2], m[3]] if m
+        []
+      end
+
       def build_identity(model)
         bib = val(model, :bibdata)
         ids = docids(bib)
@@ -199,10 +209,14 @@ module Metanorma
           &.then { |d| docid_text(d) } ||
           ids.reject { |d| docid_is_urn?(d) }
             .filter_map { |d| docid_text(d) }.first
+        series, number, part = parse_identity(canonical)
         Schema::Document.new(
           ids: Schema::Ids.new(
             canonical: canonical,
-            short: slug(canonical),
+            short: Mko.slug(canonical),
+            series: series,
+            number: number,
+            part: part,
             docid: ids.filter_map { |d| docid_text(d) },
             urn: ids.select { |d| docid_is_urn?(d) }
               .filter_map { |d| docid_text(d) },
@@ -302,11 +316,6 @@ module Metanorma
 
       def docid_is_urn?(d)
         val(d, :type) == "URN" || docid_text(d).to_s.start_with?("urn:")
-      end
-
-      def slug(canonical)
-        canonical.to_s.tr(" ", "-").gsub(/[^A-Za-z0-9.-]/, "")
-          .squeeze("-").downcase
       end
 
       # -- the walk ----------------------------------------------------
@@ -667,17 +676,35 @@ module Metanorma
                     payload: nil, number: nil, title: nil, obligation: nil)
         anchor ||= content_anchor(model, type)
         id = "u:#{anchor}"
+        cite_as = citation_anchor(anchor: anchor, number: number,
+                                  parent: parent, type: type)
         unit = Schema::Unit.new(
-          id: id, type: type, anchor: anchor, number: number, title: title,
+          id: id, type: type, anchor: anchor, number: number,
+          cite_as: cite_as, title: title,
           parent: parent, breadcrumb: breadcrumb.compact,
           obligation: obligation, lang: @lang, text: text,
           payload: payload_hash(payload), hash: content_hash(text, payload)
         )
         @units << unit
+        @units_by_id[id] = unit
         if parent
           @edges << Schema::Edge.new(from: id, to: parent, kind: "part_of")
         end
         unit
+      end
+
+      # Embedded objects cite their containing clause: a table in §4.1.2
+      # is cited as 4.1.2, not as its own anchor. Top-level sections and
+      # parentless units cite their own number/anchor.
+      def citation_anchor(anchor:, number:, parent:, type:)
+        own = number || anchor
+        if parent && @units_by_id
+          pu = @units_by_id[parent]
+          if pu && %w[clause annex].include?(pu.type)
+            return (pu.number || pu.anchor || own).to_s
+          end
+        end
+        own&.to_s
       end
 
       def payload_hash(payload)

--- a/lib/metanorma/mko/project.rb
+++ b/lib/metanorma/mko/project.rb
@@ -193,14 +193,16 @@ module Metanorma
 
       # -- identity ----------------------------------------------------
 
-      # "OIML R 60-1" → ["R", "60", "1"]; "ISO 17301-1" likewise.
-      # Nil-safe: an unparseable canonical yields nils (fields absent in
+      # Identity comes from the native pubid parser first (one parser,
+      # every publisher it covers); the series-letter regex remains as
+      # the fallback for publishers pubid does not model. Nil-safe: an unparseable canonical yields nils (fields absent in
       # JSON), never a crash — unknown shapes stay visible, not fatal.
       def parse_identity(canonical)
-        m = canonical.to_s.match(/\A(?:[A-Z][A-Za-z0-9&-]*\s+)?([A-Z])\s*(\d+)(?:-(\d+|[A-Za-z][A-Za-z0-9]*))?\b/)
-        return [m[1], m[2], m[3]] if m
+        native = Document::NativeModels.pubid_identity(canonical)
+        return native if native
 
-        []
+        m = canonical.to_s.match(/\A(?:[A-Z][A-Za-z0-9&-]*\s+)?([A-Z])\s*(\d+)(?:-(\d+|[A-Za-z][A-Za-z0-9]*))?\b/)
+        m ? [m[1], m[2], m[3]] : []
       end
 
       def build_identity(model)

--- a/lib/metanorma/mko/schema.rb
+++ b/lib/metanorma/mko/schema.rb
@@ -12,6 +12,8 @@ module Metanorma
       autoload :Edge, "metanorma/mko/schema/edge"
       autoload :Identifiers, "metanorma/mko/schema/identifiers"
       autoload :JsonSchema, "metanorma/mko/schema/json_schema"
+      autoload :Collection, "metanorma/mko/schema/collection"
+      autoload :CollectionMember, "metanorma/mko/schema/collection"
       autoload :IdentifierInfo, "metanorma/mko/schema/identifiers"
     end
   end

--- a/lib/metanorma/mko/schema/collection.rb
+++ b/lib/metanorma/mko/schema/collection.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Mko
+    module Schema
+      # collection.json — the family contract for collection bundles:
+      # membership and cross-document edges between documents that a
+      # metanorma collection.yml declares together (OIML R 60 parts,
+      # R 129/138/144 families).
+      class CollectionMember < Lutaml::Model::Serializable
+        attribute :bundle, :string
+        attribute :docidentifier, :string
+        attribute :identifier, :string
+        attribute :title, :string
+        attribute :edition, :string
+
+        json do
+          map "bundle", to: :bundle
+          map "docidentifier", to: :docidentifier
+          map "identifier", to: :identifier
+          map "title", to: :title
+          map "edition", to: :edition
+        end
+      end
+
+      class Collection < Lutaml::Model::Serializable
+        attribute :canonical, :string
+        attribute :short, :string
+        attribute :title, :string
+        attribute :edition, :string
+        attribute :members, CollectionMember, collection: true,
+                                              default: -> { [] }
+
+        json do
+          map "canonical", to: :canonical
+          map "short", to: :short
+          map "title", to: :title
+          map "edition", to: :edition
+          map "members", to: :members
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/mko/schema/document.rb
+++ b/lib/metanorma/mko/schema/document.rb
@@ -6,12 +6,22 @@ module Metanorma
       class Ids < Lutaml::Model::Serializable
         attribute :canonical, :string
         attribute :short, :string
+        # parsed identity (issue #50 follow-up 1): consumers filter and
+        # group on series/number/part — they must never decompose the
+        # canonical string themselves (a silent parse failure on the
+        # consumer side hid a whole corpus lane from retrieval)
+        attribute :series, :string
+        attribute :number, :string
+        attribute :part, :string
         attribute :docid, :string, collection: true
         attribute :urn, :string, collection: true
 
         json do
           map "canonical", to: :canonical
           map "short", to: :short
+          map "series", to: :series
+          map "number", to: :number
+          map "part", to: :part
           map "docid", to: :docid
           map "urn", to: :urn
         end

--- a/lib/metanorma/mko/schema/json_schema.rb
+++ b/lib/metanorma/mko/schema/json_schema.rb
@@ -43,6 +43,7 @@ module Metanorma
               "manifest" => schema_for(Manifest),
               "document" => schema_for(Document),
               "identifiers" => schema_for(Identifiers),
+              "collection" => schema_for(Schema::Collection),
               "payload-table" => schema_for(TablePayload),
               "payload-formula" => schema_for(FormulaPayload),
               "payload-figure" => schema_for(FigurePayload),

--- a/lib/metanorma/mko/schema/unit.rb
+++ b/lib/metanorma/mko/schema/unit.rb
@@ -134,6 +134,11 @@ module Metanorma
         attribute :type, :string
         attribute :anchor, :string
         attribute :number, :string
+        # the anchor a READER cites (issue #50 follow-up 2): the parent
+        # clause number for embedded objects (tables/formulas/figures),
+        # the unit's own number for top-level sections. Consumers cite
+        # identically without walking the parent chain.
+        attribute :cite_as, :string
         attribute :title, :string
         attribute :parent, :string
         attribute :breadcrumb, :string, collection: true, default: -> { [] }
@@ -148,6 +153,7 @@ module Metanorma
           map "type", to: :type
           map "anchor", to: :anchor
           map "number", to: :number
+          map "cite_as", to: :cite_as
           map "title", to: :title
           map "parent", to: :parent
           map "breadcrumb", to: :breadcrumb

--- a/lib/metanorma/mko/writer.rb
+++ b/lib/metanorma/mko/writer.rb
@@ -2,56 +2,36 @@
 
 module Metanorma
   module Mko
-    # Writes a projection Result as an MKO bundle directory (or zip).
-    # Each line of units.jsonl / edges.jsonl is the framework-generated
-    # to_json of one schema object.
+    # Maps a projection Result onto a bundle directory (or zip). The
+    # on-disk mechanics live in Bundle; this class only decides which
+    # components a document projection produces.
     module Writer
       class << self
         def write(result, to:, zip: false)
-          dir = bundle_dir(result, to)
-          FileUtils.rm_rf(dir)
-          FileUtils.mkdir_p(dir)
-          manifest = write_components(result, dir)
-          File.write(File.join(dir, "manifest.json"),
-                     JSON.pretty_generate(JSON.parse(manifest.to_json)))
-          zip ? zip_bundle(dir) : dir
+          bundle = Bundle.open(result.document.ids.short, to)
+          bundle.flavor = result.flavor
+          add_components(bundle, result)
+          bundle.write_manifest
+          zip ? bundle.zip! : bundle.dir
         end
 
         private
 
-        def bundle_dir(result, to)
-          name = "#{result.document.ids.short || 'document'}.mko"
-          File.expand_path(File.join(to, name))
-        end
-
-        def write_components(result, dir)
-          manifest = Schema::Manifest.new(
-            schema: SCHEMA, schema_version: SCHEMA_VERSION,
-            generated: Schema::Generated.new(
-              tool: "metanorma-document", schema_version: SCHEMA_VERSION,
-              flavor: result.flavor, timestamp: Time.now.utc.iso8601
-            ),
-            components: []
-          )
-          add_component(manifest, dir, "document", "document.json",
-                        "application/json", result.document)
+        def add_components(bundle, result)
+          bundle.add_json("document", "document.json", result.document)
           # bibdata/glossary/identifiers carry the NATIVE object-model
           # serializations (Relaton::Bib, Glossarist::Concept, Pubid),
           # produced by Document::NativeModels at the model layer.
           if result.bibdata
-            add_component(manifest, dir, "bibdata", "bibdata.json",
-                          "application/json", result.bibdata)
+            bundle.add_json("bibdata", "bibdata.json", result.bibdata)
           end
-          add_component(manifest, dir, "identifiers", "identifiers.json",
-                        "application/json", result.identifiers)
-          glossary = { "concepts" => result.glossary.map do |c|
-            JSON.parse(c.to_json)
-          end }
-          add_component(manifest, dir, "glossary", "glossary.json",
-                        "application/json", glossary)
+          bundle.add_json("identifiers", "identifiers.json", result.identifiers)
+          bundle.add_json("glossary", "glossary.json",
+                          { "concepts" => result.glossary.map do |c|
+                            JSON.parse(c.to_json)
+                          end })
           # bibliography.jsonl: every cited document as native objects —
-          # Relaton item + pubid parse — keyed to its reference unit, so
-          # citation edges resolve to documents instead of strings.
+          # Relaton item + pubid parse — keyed to its reference unit.
           bib_lines = result.bibliography.map do |e|
             {
               "unit" => "u:#{e.key}",
@@ -61,65 +41,12 @@ module Metanorma
               "bibitem" => e.item && JSON.parse(e.item.to_json),
             }
           end
-          write_lines(manifest, dir, "bibliography", "bibliography.jsonl",
-                      bib_lines) { |line| JSON.generate(line) }
-          write_lines(manifest, dir, "units", "units.jsonl", result.units)
-          write_lines(manifest, dir, "edges", "edges.jsonl", result.edges)
-          write_assets(manifest, dir, result.assets)
-          manifest
-        end
-
-        def add_component(manifest, dir, name, file, media_type, object)
-          path = File.join(dir, file)
-          File.write(path, JSON.pretty_generate(JSON.parse(object.to_json)))
-          manifest.components << Schema::ManifestComponent.new(
-            name: name, file: file, media_type: media_type,
-            hash: file_hash(path)
-          )
-        end
-
-        # Line-oriented component whose values are already-serialized
-        # native JSON objects (framework to_json upstream).
-        def write_lines(manifest, dir, name, file, objects, &serializer)
-          serializer ||= lambda(&:to_json)
-          path = File.join(dir, file)
-          File.write(path, "#{objects.map(&serializer).join("\n")}\n")
-          manifest.components << Schema::ManifestComponent.new(
-            name: name, file: file, media_type: "application/jsonl",
-            count: objects.size, hash: file_hash(path)
-          )
-        end
-
-        # Hash-addressed asset components: bytes land as
-        # assets/<sha256>, manifest-verified like every component.
-        def write_assets(manifest, dir, entries)
-          entries.each do |entry|
-            path = File.join(dir, entry.name)
-            FileUtils.mkdir_p(File.dirname(path))
-            File.binwrite(path, entry.data)
-            manifest.components << Schema::ManifestComponent.new(
-              name: entry.name, file: entry.name,
-              media_type: entry.media_type, count: 1,
-              hash: file_hash(path)
-            )
+          bundle.add_lines("bibliography", "bibliography.jsonl", bib_lines) do |l|
+            JSON.generate(l)
           end
-        end
-
-        def file_hash(path)
-          "sha256:#{Digest::SHA256.file(path).hexdigest}"
-        end
-
-        def zip_bundle(dir)
-          zip_path = "#{dir}.zip"
-          require "zip"
-          Zip::File.open(zip_path, Zip::File::CREATE) do |zipfile|
-            Dir[File.join(dir, "**", "*")].each do |f|
-              next if File.directory?(f)
-
-              zipfile.add(f.sub("#{dir}/", ""), f)
-            end
-          end
-          zip_path
+          bundle.add_lines("units", "units.jsonl", result.units)
+          bundle.add_lines("edges", "edges.jsonl", result.edges)
+          result.assets.each { |entry| bundle.add_asset(entry) }
         end
       end
     end

--- a/spec/fixtures/collection/mini/collection.yml
+++ b/spec/fixtures/collection/mini/collection.yml
@@ -1,0 +1,20 @@
+directives:
+  - flavor: ogc
+bibdata:
+  title:
+    - language: en
+      type: title-main
+      content: "Sensor network requirements collection"
+  type: collection
+  docid:
+    type: oiml
+    id: SNR Family
+  edition: "1"
+manifest:
+  level: document
+  title: Documents
+  docref:
+    - fileref: member-1.xml
+      identifier: SNR-1
+    - fileref: member-2.xml
+      identifier: SNR-2

--- a/spec/fixtures/collection/mini/member-1.xml
+++ b/spec/fixtures/collection/mini/member-1.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metanorma xmlns="https://www.metanorma.org/ns/standoc" type="semantic" flavor="ogc">
+<bibdata type="standard">
+<title language="en" type="main">Sensor network requirements</title>
+<docidentifier type="ogc-internal" primary="true">SNR-1</docidentifier>
+<docnumber>1</docnumber>
+<edition>1</edition>
+<language>en</language>
+<status><stage>published</stage></status>
+<contributor><role type="publisher"/><organization><name>Metanorma</name></organization></contributor>
+<copyright><from>2026</from><owner><organization><name>Metanorma</name></organization></owner></copyright>
+<relation type="obsoletes"><bibitem><docidentifier type="ogc-internal">SNR-0</docidentifier></bibitem></relation>
+<relation type="hasPart"><bibitem><docidentifier type="ogc-internal">SNR-2</docidentifier></bibitem></relation>
+</bibdata>
+<sections>
+<clause id="_sec-req" anchor="sensor-requirements" obligation="normative" displayorder="2">
+<title>Sensor requirements</title>
+<p id="_p-intro">This clause states the requirements for sensor nodes.</p>
+<requirement id="_req-accuracy" anchor="req-sensor-accuracy" obligation="requirement">
+<subject>sensors</subject>
+<classification><tag>class</tag><value>accuracy</value></classification>
+<description><p id="_p-acc">Sensor readings shall be accurate to within ±0.1 % of the reference value.</p></description>
+<inherit><eref type="inline" bibitemid="SNR0" citeas="SNR 0">SNR 0</eref></inherit>
+</requirement>
+<permission id="_perm-maintenance" anchor="perm-maintenance" obligation="permission">
+<subject>sensors</subject>
+<description><p id="_p-maint">Maintenance may be performed while the network is operational.</p></description>
+</permission>
+<recommendation id="_rec-calibration" anchor="rec-calibration" obligation="recommendation">
+<subject>sensors</subject>
+<description><p id="_p-cal">Sensors should be calibrated at least every twelve months.</p></description>
+</recommendation>
+<requirement id="_req-parent" anchor="req-battery" obligation="requirement">
+<subject>sensors</subject>
+<classification><tag>class</tag><value>battery</value></classification>
+<description><p id="_p-bat">Battery-powered sensors shall sleep between measurements.</p></description>
+<requirement id="_req-child" anchor="req-battery-life" obligation="requirement">
+<subject>sensors</subject>
+<description><p id="_p-life">Battery life shall exceed twelve months.</p></description>
+</requirement>
+</requirement>
+</clause>
+</sections>
+<annex id="_annex-terms" obligation="normative">
+<title>Additional terms</title>
+<terms id="_annex-terms-sec">
+<title>Terms and definitions</title>
+<term id="_term-annex-load-cell" anchor="term-annex-load-cell">
+<preferred><expression><name>annex load cell</name></expression></preferred>
+<definition><verbal-definition><p id="_p-annex-def">a load cell defined in an annex</p></verbal-definition></definition>
+</term>
+</terms>
+</annex>
+<bibliography><references id="_rf-norm" normative="true" obligation="informative">
+<title>Normative references</title>
+<bibitem id="SNR0"><formattedref format="application/x-isodoc+xml"><em>SNR 0</em></formattedref><docidentifier type="ogc-internal">SNR-0</docidentifier></bibitem>
+</references></bibliography>
+</metanorma>

--- a/spec/fixtures/collection/mini/member-2.xml
+++ b/spec/fixtures/collection/mini/member-2.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metanorma xmlns="https://www.metanorma.org/ns/standoc" type="semantic" flavor="ogc">
+<bibdata type="standard">
+<title language="en" type="main">Sensor network requirements</title>
+<docidentifier type="ogc-internal" primary="true">SNR-2</docidentifier>
+<docnumber>1</docnumber>
+<edition>1</edition>
+<language>en</language>
+<status><stage>published</stage></status>
+<contributor><role type="publisher"/><organization><name>Metanorma</name></organization></contributor>
+<copyright><from>2026</from><owner><organization><name>Metanorma</name></organization></owner></copyright>
+<relation type="obsoletes"><bibitem><docidentifier type="ogc-internal">SNR-0</docidentifier></bibitem></relation>
+<relation type="hasPart"><bibitem><docidentifier type="ogc-internal">SNR-2</docidentifier></bibitem></relation>
+</bibdata>
+<sections>
+<clause id="_sec-req" anchor="sensor-requirements" obligation="normative" displayorder="2">
+<title>Sensor requirements</title>
+<p id="_p-intro">This clause states the requirements for sensor nodes.</p>
+<requirement id="_req-accuracy" anchor="req-sensor-accuracy" obligation="requirement">
+<subject>sensors</subject>
+<classification><tag>class</tag><value>accuracy</value></classification>
+<description><p id="_p-acc">Sensor readings shall be accurate to within ±0.1 % of the reference value.</p></description>
+<inherit><eref type="inline" bibitemid="SNR0" citeas="SNR 0">SNR 0</eref></inherit>
+</requirement>
+<permission id="_perm-maintenance" anchor="perm-maintenance" obligation="permission">
+<subject>sensors</subject>
+<description><p id="_p-maint">Maintenance may be performed while the network is operational.</p></description>
+</permission>
+<recommendation id="_rec-calibration" anchor="rec-calibration" obligation="recommendation">
+<subject>sensors</subject>
+<description><p id="_p-cal">Sensors should be calibrated at least every twelve months.</p></description>
+</recommendation>
+<requirement id="_req-parent" anchor="req-battery" obligation="requirement">
+<subject>sensors</subject>
+<classification><tag>class</tag><value>battery</value></classification>
+<description><p id="_p-bat">Battery-powered sensors shall sleep between measurements.</p></description>
+<requirement id="_req-child" anchor="req-battery-life" obligation="requirement">
+<subject>sensors</subject>
+<description><p id="_p-life">Battery life shall exceed twelve months.</p></description>
+</requirement>
+</requirement>
+</clause>
+</sections>
+<annex id="_annex-terms" obligation="normative">
+<title>Additional terms</title>
+<terms id="_annex-terms-sec">
+<title>Terms and definitions</title>
+<term id="_term-annex-load-cell" anchor="term-annex-load-cell">
+<preferred><expression><name>annex load cell</name></expression></preferred>
+<definition><verbal-definition><p id="_p-annex-def">a load cell defined in an annex</p></verbal-definition></definition>
+</term>
+</terms>
+</annex>
+<bibliography><references id="_rf-norm" normative="true" obligation="informative">
+<title>Normative references</title>
+<bibitem id="SNR0"><formattedref format="application/x-isodoc+xml"><em>SNR 0</em></formattedref><docidentifier type="ogc-internal">SNR-0</docidentifier></bibitem>
+</references></bibliography>
+</metanorma>

--- a/spec/metanorma/document/native_models_spec.rb
+++ b/spec/metanorma/document/native_models_spec.rb
@@ -59,6 +59,17 @@ RSpec.describe Metanorma::Document::NativeModels do
     end
   end
 
+  describe ".pubid_identity" do
+    it "parses series/number/part across publishers natively" do
+      expect(described_class.pubid_identity("OIML R 60-1:2017"))
+        .to eq(["R", "60", "1"])
+      expect(described_class.pubid_identity("OIML D 11"))
+        .to eq(["D", "11", nil])
+      expect(described_class.pubid_identity("ISO 17301-1:2016"))
+        .to eq([nil, "17301", "1"])
+    end
+  end
+
   describe ".relaton_bibliography" do
     it "exports every bibitem as a native Relaton item with a pubid" do
       entries = described_class.relaton_bibliography(model)

--- a/spec/metanorma/mko/alignment_spec.rb
+++ b/spec/metanorma/mko/alignment_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fileutils"
+require "tmpdir"
+
+RSpec.describe Metanorma::Mko::Alignment do
+  let(:xml) do
+    File.read(fixture_path("standoc/requirements/document.xml"),
+              encoding: "utf-8")
+  end
+  let(:dir) { Dir.mktmpdir("align") }
+
+  def fixture_path(rel)
+    File.expand_path("../../fixtures/#{rel}", __dir__)
+  end
+
+  after { FileUtils.remove_entry(dir) }
+
+  it "aligns same-anchored units across editions with variant_of" do
+    a = Metanorma::Mko.export(xml, to: dir)
+    b = Metanorma::Mko.export(xml, to: dir)
+    edges = described_class.align(a, b)
+    expect(edges).not_to be_empty
+    edges.each do |e|
+      expect(e.kind).to eq("variant_of")
+      expect(e.from).to start_with("u:")
+      expect(e.from).to eq(e.to) # same doc: anchors pair with themselves
+    end
+    # anchored semantic units participate; hash-fallback anchors do not
+    expect(edges.map(&:from)).to include("u:req-sensor-accuracy")
+    expect(edges.map(&:from)).not_to include(match(/\Ah-/))
+
+    path = described_class.export(a, b)
+    lines = File.readlines(path).map { |l| JSON.parse(l) }
+    expect(lines.size).to eq(edges.size)
+    expect(lines.first["kind"]).to eq("variant_of")
+  end
+end

--- a/spec/metanorma/mko/collection_spec.rb
+++ b/spec/metanorma/mko/collection_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_string: true
+
+require "spec_helper"
+require "fileutils"
+require "tmpdir"
+
+RSpec.describe Metanorma::Mko::Collection do
+  let(:yml_path) do
+    File.expand_path("../../fixtures/collection/mini/collection.yml",
+                     __dir__)
+  end
+  let(:out) { Dir.mktmpdir("mko-collection") }
+
+  after { FileUtils.remove_entry(out) }
+
+  def read_json(bundle, file)
+    JSON.parse(File.read(File.join(bundle, file)))
+  end
+
+  def read_lines(bundle, file)
+    File.readlines(File.join(bundle, file)).map { |l| JSON.parse(l) }
+  end
+
+  it "exports every member and the membership bundle" do
+    result = described_class.export(yml_path, to: out)
+    expect(result.skipped).to be_empty
+
+    # member bundles: the document bundle is the unit of truth
+    members = Dir[File.join(out, "*.mko")].select { |p| File.directory?(p) }
+    expect(members.size).to eq(3) # two members + the collection
+
+    collection = read_json(result.collection_bundle, "collection.json")
+    expect(collection["canonical"]).to eq("SNR Family")
+    expect(collection["short"]).to eq("snr-family")
+    expect(collection["members"].size).to eq(2)
+    docids = collection["members"].map { |m| m["docidentifier"] }
+    expect(docids).to contain_exactly("SNR-1", "SNR-2")
+    expect(collection["members"].first["bundle"]).to end_with(".mko")
+
+    # cross-document family edges
+    edges = read_lines(result.collection_bundle, "edges.jsonl")
+    expect(edges).to contain_exactly(
+      { "from" => "doc:SNR-1", "to" => "doc:SNR Family", "kind" => "part_of" },
+      { "from" => "doc:SNR-2", "to" => "doc:SNR Family", "kind" => "part_of" },
+    )
+
+    # manifest-verified like every bundle
+    manifest = read_json(result.collection_bundle, "manifest.json")
+    expect(manifest["schema"]).to eq("metanorma-mko")
+    names = manifest["components"].map { |c| c["name"] }
+    expect(names).to include("collection", "edges")
+    manifest["components"].each do |c|
+      digest = Digest::SHA256.file(File.join(result.collection_bundle, c["file"])).hexdigest
+      expect(c["hash"]).to eq("sha256:#{digest}")
+    end
+  end
+
+  it "records members without compiled XML instead of failing" do
+    broken = File.join(out, "broken.yml")
+    File.write(broken, <<~YML)
+      bibdata:
+        docid: { id: "Broken Fam" }
+      manifest:
+        docref:
+          - fileref: missing.adoc
+            identifier: X-1
+    YML
+    result = described_class.export(File.read(broken), to: out)
+    expect(result.skipped.size).to eq(1)
+    expect(result.skipped.first.identifier).to eq("X-1")
+    expect(result.members.select(&:skipped).size).to eq(1)
+  end
+end

--- a/spec/metanorma/mko/export_spec.rb
+++ b/spec/metanorma/mko/export_spec.rb
@@ -89,6 +89,8 @@ RSpec.describe Metanorma::Mko do
       bundle = export!
       document = read_json(bundle, "document.json")
       expect(document["doctype"]).to eq("international-standard")
+      expect(document["ids"]["number"]).to eq("17301")
+      expect(document["ids"]["part"]).to eq("1")
       expect(document["edition"]).to eq("2")
       expect(document["status"]["stage"]).to eq("60")
       expect(document["status"]["abbreviation"]).to eq("IS")


### PR DESCRIPTION
Implements follow-ups 1 and 2 from #50, both proven by production incidents on the OIML SMART AI consumer:

**1. Parsed identity — `ids.series` / `ids.number` / `ids.part` in `document.json`.** Derived from the canonical at build time (`"OIML R 60-1"` → `R` / `60` / `1`); unparseable canonicals yield absent fields, never a crash. Why: our consumer regex-parsed `doc_number` from the canonical to drive Vectorize filters and graph joins — when the parse silently failed, an entire corpus lane became invisible to doc-scoped retrieval. Consumers should never decompose identifiers.

**2. `cite_as` on every unit.** The anchor a reader cites: the **parent clause number** for embedded objects (a table in §4.1.2 cites as `5.1.2`-style, not `table-1`), the unit's own number for top-level sections. Why: our reranker, citations, and golden cases all key on clause numbers; we derived parent-clause anchoring at ingest until now.

Verified on a real export (mn-samples r060/1):

```
identity: series=R number=60 part=1
table table-1 cite_as="5.1.2" parent_type=clause
table table-2 cite_as="5.1.6" parent_type=clause
```

Consumer side is ready to adopt both the moment this merges (the OIML SMART AI ingest prefers `cite_as` when present). Stacked on `feat/model-validation-l1-declarations` like #49.
