### PR TITLE
Sections resolve the element language (#53 item 3, walk half — resolving)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem "metanorma-core", github: "metanorma/metanorma-core", branch: "main"
 gem "metanorma-iec", github: "metanorma/metanorma-iec", branch: "main"
 gem "metanorma-iso", github: "metanorma/metanorma-iso", branch: "feat/model-validation-migration"
 gem "metanorma-itu", github: "metanorma/metanorma-itu", branch: "main"
+# mko >= 1.1.0 from rubygems carries Mko::Language
 gem "metanorma-mko"
 gem "metanorma-ogc", github: "metanorma/metanorma-ogc", branch: "main"
 gem "metanorma-standoc", github: "metanorma/metanorma-standoc", branch: "main"

--- a/lib/metanorma/document/mko/project.rb
+++ b/lib/metanorma/document/mko/project.rb
@@ -33,7 +33,11 @@ module Metanorma
         # units register (#55): entries + symbol lookup for formula refs
         @unitsml = []
         @units_by_symbol = {}
-        @lang = first_lang(model)
+        # The document language resolution (#53 item 3): every unit's
+        # lang carries its provenance — markup, heuristic, default, or
+        # the explicit fallback (Mko::Language).
+        @document_lang = resolve_document_lang(model)
+        @lang = @document_lang
         @flavor = flavor_of(model)
         @doc_date = published_on(model)
       end
@@ -51,7 +55,7 @@ module Metanorma
         Mko::Result.new(document: identity, units: @units, edges: @edges,
                         unitsml: @unitsml,
                         glossary: Document::NativeModels.glossarist_concepts(
-                          @model, lang: @lang, date: @doc_date
+                          @model, lang: @lang.lang, date: @doc_date
                         ),
                         bibdata: Document::NativeModels.relaton_bibdata(@model),
                         bibliography:
@@ -131,20 +135,45 @@ module Metanorma
           model.class.name.to_s.split("::")[1]&.downcase
       end
 
-      # Element-level language override (#53 item 3): returns the
-      # @lang to restore when the scope ends. The model layer carries
-      # :lang only when it maps xml:lang — absent attributes read nil
-      # and the document language stands.
-      def push_element_lang(element)
+      # Element-level language resolution (#53 item 3): the element's
+      # own :lang wins the day the models map xml:lang
+      # (metanorma-standoc#1243) — markup stays authoritative; with no
+      # xml:lang in scope the element's own prose decides (the stopword
+      # langid the RAG consumer shares — a translated annex tags
+      # itself); else the enclosing scope, then the document default,
+      # stands. Returns the resolution to restore when the scope ends.
+      def push_element_lang(element, text: nil)
         previous = @lang
-        lang = val(element, :lang)
-        @lang = lang unless lang.nil? || lang.to_s.empty?
+        @lang = Mko::Language.resolve(own: val(element, :lang),
+                                      text: text, inherited: previous,
+                                      default: @document_lang)
         previous
+      end
+
+      # The document-level chain: the root's :lang the day the models
+      # map the root xml:lang, else the declared bibdata language, else
+      # detection over the document's own prose, else the explicit
+      # fallback.
+      def resolve_document_lang(model)
+        Mko::Language.document(markup: val(model, :lang),
+                               declared: first_lang(model),
+                               text: document_sample(model))
       end
 
       def first_lang(model)
         bib = val(model, :bibdata)
         scalar(vals(bib, :language).first)
+      end
+
+      # The document-level detection sample: the direct prose of every
+      # top-level section (SAMPLE_WORDS caps what detect reads).
+      def document_sample(model)
+        parts = []
+        each_top_section(model) do |s|
+          text = section_text(s)
+          parts << text unless text.empty?
+        end
+        parts.join("\n")
       end
 
       # -- numbering (presentation model) ----------------------------
@@ -506,11 +535,13 @@ module Metanorma
         walk_bibliography(model)
       end
 
-      # Sections scope the element-level language (#53 item 3): a
-      # translated annex/term carries its own xml:lang the day the
-      # models map it — every unit emitted inside inherits it.
+      # Sections scope the element-level language (#53 item 3): the
+      # section's resolution — its own xml:lang the day the models map
+      # it, else its own prose, else the enclosing scope — applies to
+      # every unit emitted inside.
       def walk_section(section, type: "clause", parent: nil, breadcrumb: [])
-        restore_lang = push_element_lang(section)
+        text = section_text(section)
+        restore_lang = push_element_lang(section, text: text)
         begin
           anchor = element_anchor(section)
           number = @numbers[anchor] || section_autonum(section)
@@ -519,7 +550,7 @@ module Metanorma
             type: type, anchor: anchor, number: number, title: title,
             parent: parent, breadcrumb: breadcrumb,
             obligation: val(section, :obligation),
-            text: section_text(section), model: section
+            text: text, model: section
           )
           crumb = breadcrumb + [number ? "#{number} #{title}" : title]
           node = Schema::StructureNode.new(id: unit.id, number: number,
@@ -550,7 +581,8 @@ module Metanorma
       end
 
       def walk_terms_section(tsec, parent: nil, breadcrumb: [])
-        restore_lang = push_element_lang(tsec)
+        text = section_text(tsec)
+        restore_lang = push_element_lang(tsec, text: text)
         begin
           anchor = element_anchor(tsec)
           number = @numbers[anchor] || section_autonum(tsec)
@@ -558,7 +590,7 @@ module Metanorma
           unit = emit_unit(
             type: "clause", anchor: anchor, number: number, title: title,
             parent: parent, breadcrumb: breadcrumb,
-            obligation: val(tsec, :obligation), text: section_text(tsec),
+            obligation: val(tsec, :obligation), text: text,
             model: tsec
           )
           crumb = breadcrumb + [title]
@@ -629,7 +661,9 @@ module Metanorma
         end
         indices = Hash.new(0)
         parts = []
-        section.element_order.each do |el|
+        # element_order is nil on programmatically built (unparsed)
+        # models — the declaration-order fallback below covers them
+        Array(section.element_order).each do |el|
           next unless el.is_a?(Lutaml::Xml::Element)
 
           attr = SECTION_PROSE_SOURCES[el.name.to_s] or next
@@ -875,7 +909,7 @@ module Metanorma
           h[name] = { list: attrs.flat_map { |a| vals(section, a) }, idx: 0 }
         end
         ordered = []
-        section.element_order.each do |el|
+        Array(section.element_order).each do |el|
           next unless el.is_a?(Lutaml::Xml::Element)
 
           pool = pools[el.name.to_s] or next
@@ -933,7 +967,8 @@ module Metanorma
           id: id, type: type, anchor: anchor, number: number,
           ordinal: @ordinal, cite_as: cite_as, title: title,
           parent: parent, breadcrumb: breadcrumb.compact,
-          obligation: obligation, lang: @lang, text: text,
+          obligation: obligation, lang: @lang.lang,
+          lang_source: @lang.source, text: text,
           payload: payload_hash(payload), hash: content_hash(text, payload)
         )
         @ordinal += 1

--- a/spec/fixtures/iso/is/document-en-fr-annex.xml
+++ b/spec/fixtures/iso/is/document-en-fr-annex.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metanorma xmlns="https://www.metanorma.org/ns/standoc" type="semantic" version="3.3.4" schema-version="v2.1.5" flavor="iso">
+<bibdata type="standard">
+<title language="en" type="main">Weighing instruments — Metrological and technical requirements</title>
+<docidentifier type="ISO" primary="true">ISO 9999:2026</docidentifier>
+<docnumber>9999</docnumber>
+<edition>1</edition>
+<language>en</language>
+<status><stage abbreviation="IS">60</stage></status>
+<contributor><role type="publisher"/><organization><name>International Organization for Standardization</name><abbreviation>ISO</abbreviation></organization></contributor>
+<copyright><from>2026</from><owner><organization><name>International Organization for Standardization</name><abbreviation>ISO</abbreviation></organization></owner></copyright>
+<ext><doctype>international-standard</doctype><flavor>iso</flavor><stagename abbreviation="IS">International Standard</stagename></ext>
+</bibdata>
+<sections>
+<clause id="_sec-scope" type="scope" inline-header="false" obligation="normative">
+<title id="_t-scope">Scope</title>
+<p id="_p-scope-1">This document specifies the metrological and technical requirements that weighing instruments shall satisfy. For the purposes of this document, the terms and definitions given in the following clauses apply. The requirements of this clause are normative and shall be verified by the tests that are described in the annex.</p>
+</clause>
+<clause id="_sec-reserved" inline-header="false" obligation="normative">
+<title id="_t-reserved">Future requirements</title>
+<p id="_p-reserved">Reserved.</p>
+</clause>
+</sections>
+<annex id="_annex-a" anchor="annex-a" obligation="informative">
+<title id="_t-annex-a">Termes et définitions</title>
+<p id="_p-annex-intro">Le présent document spécifie les exigences métrologiques et techniques auxquelles les instruments de pesage doivent satisfaire. Pour les besoins du présent document, les termes et définitions suivants s'appliquent. Les définitions données dans la présente section sont conformes au Vocabulaire international de métrologie.</p>
+<terms id="_annex-terms" obligation="informative">
+<title id="_t-annex-terms">Termes</title>
+<term id="_term-instrument" anchor="term-instrument-de-pesage"><preferred><expression>
+<name>instrument de pesage</name>
+</expression>
+</preferred>
+<definition id="_def-instrument"><verbal-definition id="_vd-instrument"><p id="_p-def-instrument">instrument servant à déterminer la masse d'un corps en utilisant l'action de la pesanteur sur ce corps</p></verbal-definition></definition>
+</term>
+<term id="_term-charge" anchor="term-charge"><preferred><expression>
+<name>charge</name>
+</expression>
+</preferred>
+<definition id="_def-charge"><verbal-definition id="_vd-charge"><p id="_p-def-charge">valeur de la masse du poids ou de la marchandise que l'instrument doit mesurer dans les conditions normales d'utilisation</p></verbal-definition></definition>
+</term>
+</terms>
+</annex>
+</metanorma>

--- a/spec/metanorma/mko/export_spec.rb
+++ b/spec/metanorma/mko/export_spec.rb
@@ -89,6 +89,16 @@ RSpec.describe Metanorma::Mko do
       expect(document["ids"]["short"]).to match(/\A[a-z0-9.-]+\z/)
     end
 
+    # lang provenance (#53 item 3): every unit carries how its lang
+    # was resolved — an all-English fixture resolves via section prose
+    # or the declared document language (no xml:lang anywhere)
+    it "carries the language resolution's provenance on every unit" do
+      bundle = export!
+      read_lines(bundle, "units.jsonl").each do |u|
+        expect(u["lang_source"]).to match(/\A(heuristic|default)\z/)
+      end
+    end
+
     it "carries parsed identity: doctype, edition, status, structure" do
       bundle = export!
       document = read_json(bundle, "document.json")

--- a/spec/metanorma/mko/language_spec.rb
+++ b/spec/metanorma/mko/language_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fileutils"
+require "tmpdir"
+
+# The walk's language resolution (#53 item 3), consumer-side of
+# metanorma-standoc#1243: with no element-level xml:lang emitted or
+# mapped, a section resolves from its own prose (the Mko::Language
+# stopword langid), then the enclosing scope, then the declared
+# document language, then the explicit fallback — and every unit
+# carries the provenance as lang_source.
+RSpec.describe Metanorma::Mko::Project do
+  let(:fixture_xml) do
+    File.read(
+      File.expand_path("../../fixtures/iso/is/document-en-fr-annex.xml",
+                       __dir__), encoding: "utf-8"
+    )
+  end
+  let(:model) { Metanorma::Iso::Document::Root.from_xml(fixture_xml) }
+  let(:result) { described_class.call(model) }
+  let(:units_by_id) { result.units.to_h { |u| [u.id, u] } }
+  let(:tmpdir) { Dir.mktmpdir("mko-lang-spec") }
+
+  after { FileUtils.rm_rf(tmpdir) }
+
+  it "tags the English body from its own prose" do
+    unit = units_by_id["u:_sec-scope"]
+    expect(unit.lang).to eq("en")
+    expect(unit.lang_source).to eq("heuristic")
+  end
+
+  it "tags a translated annex from its own prose — the canonical " \
+     "case (an EN edition's French terminology annex is official " \
+     "content to be tagged, not excluded)" do
+    unit = units_by_id["u:annex-a"]
+    expect(unit.lang).to eq("fr")
+    expect(unit.lang_source).to eq("heuristic")
+  end
+
+  it "scopes the annex's terms section and term entries to the " \
+     "annex's resolution" do
+    ids = %w[u:_annex-terms u:term-instrument-de-pesage u:term-charge]
+    expect(ids.map { |id| units_by_id[id].lang }).to eq(%w[fr fr fr])
+    expect(ids.map { |id| units_by_id[id].lang_source })
+      .to all(eq("heuristic"))
+  end
+
+  it "falls to the declared document language when a section's " \
+     "prose is inconclusive" do
+    unit = units_by_id["u:_sec-reserved"]
+    expect(unit.lang).to eq("en")
+    expect(unit.lang_source).to eq("default")
+  end
+
+  it "keeps every unit's provenance discoverable" do
+    result.units.each do |u|
+      expect(u.lang_source).to match(/\A(markup|heuristic|default|fallback)\z/)
+    end
+  end
+
+  it "carries lang and lang_source on the wire" do
+    bundle = Metanorma::Mko.export(model, to: tmpdir)
+    units = File.readlines(File.join(bundle, "units.jsonl"))
+      .map { |l| JSON.parse(l) }
+    annex = units.find { |u| u["id"] == "u:annex-a" }
+    expect(annex["lang"]).to eq("fr")
+    expect(annex["lang_source"]).to eq("heuristic")
+  end
+
+  describe "element-level xml:lang (the standoc#1243 forward path)" do
+    # The models carry :lang the day they map xml:lang; ModelAccess
+    # reads absent attributes as nil. Subclasses simulate the landed
+    # upstream — the shared model classes stay untouched.
+    let(:marked_model) do
+      iso = Metanorma::Iso::Document
+      clause_class = Class.new(iso::Sections::IsoClauseSection) do
+        attribute :lang, :string
+      end
+      annex_class = Class.new(iso::Sections::IsoAnnexSection) do
+        attribute :lang, :string
+      end
+      root_class = Class.new(iso::Root) { attribute :lang, :string }
+      nested = clause_class.new(id: "_nested", lang: "de")
+      annex = annex_class.new(id: "_annex-m", anchor: "annex-m",
+                              lang: "fr", clause: [nested])
+      body = clause_class.new(id: "_body")
+      bibdata = iso::Metadata::IsoBibliographicItem.new(
+        docidentifier: [iso::Metadata::DocIdentifier.new(
+          type: "ISO", primary: true, id: "ISO 9999",
+        )],
+      )
+      root_class.new(
+        lang: "en", bibdata: bibdata,
+        sections: iso::Sections::IsoSections.new(clause: [body]),
+        annex: [annex]
+      )
+    end
+    let(:marked_units) do
+      described_class.call(marked_model).units.to_h { |u| [u.id, u] }
+    end
+
+    it "resolves the root language as markup for the whole tree" do
+      unit = marked_units["u:_body"]
+      expect(unit.lang).to eq("en")
+      expect(unit.lang_source).to eq("markup")
+    end
+
+    it "lets the nearest ancestor-or-self override win" do
+      annex = marked_units["u:annex-m"]
+      nested = marked_units["u:_nested"]
+      expect(annex.lang).to eq("fr")
+      expect(annex.lang_source).to eq("markup")
+      expect(nested.lang).to eq("de")
+      expect(nested.lang_source).to eq("markup")
+    end
+  end
+end


### PR DESCRIPTION
**Stacked on `feat/model-validation-l1-declarations`** (which carries 6c53c72's nil-safe scoping — not yet on `main`); retarget to `main` when the base merges. Companion to https://github.com/metanorma/metanorma-mko/pull/1, which ships `Mko::Language`; the Gemfile pins that branch until an mko release carries it (releasing stays the mko maintainer's act — no bump here).

## What changes

The nil-safe scoping of 6c53c72 tolerated the *absence* of `xml:lang` but resolved nothing — every unit silently took the bibdata language. This PR makes the walk resolve, per W3C XML §2.12, composing `Mko::Language`:

- **`push_element_lang(element, text:)`** — the element's own `:lang` wins the day the models map `xml:lang` (standoc#1243), markup authoritative; with **no `xml:lang` in scope**, the section's own prose decides via the shared stopword langid; else the enclosing scope, then the document default. Scoping/restore mechanics unchanged.
- **Document-level seeding** (`resolve_document_lang`): root `:lang` (mapped root `xml:lang`, forward path) → declared bibdata language → detection over the top-level sections' prose → explicit `en` fallback.
- **`emit_unit`** writes `lang: @lang.lang, lang_source: @lang.source` — every unit now carries the resolution's provenance (`markup`|`heuristic`|`default`|`fallback`), the gem's additive optional facet.
- `element_order` reads in `section_text`/`ordered_child_ids` go nil-safe: programmatically built (unparsed) models take the existing declaration-order fallback instead of crashing (the document-level sample exercises this at initialize).
- Blocks (tables/figures/formulas/notes/…) and term entries inherit their section's resolution — their own texts are too short for honest detection; section granularity is the honest level.

## Coverage

New fixture `spec/fixtures/iso/is/document-en-fr-annex.xml`: an EN ISO document embedding a French terminology annex — the canonical OIML case (official content to be *tagged*, not excluded). New `spec/metanorma/mko/language_spec.rb` (8 examples):

- French annex → `fr`/`heuristic`; its terms section + term entries inherit `fr`; EN body → `en`/`heuristic`
- inconclusive prose ("Reserved.") → declared document language, `en`/`default`
- wire check: `lang` + `lang_source` land in `units.jsonl`
- forward path: subclassed models carrying `:lang` (simulating standoc#1243 landed) — root `en` resolves the tree as markup, annex `fr` overrides, nested clause `de` wins nearest. Subclasses keep the shared model classes untouched.
- `export_spec.rb` gains a provenance guard over the real ISO corpus: every unit's `lang_source` ∈ {heuristic, default}.

## Evidence

- `bundle exec rspec` — **975 examples, 0 failures** (full suite)
- `bundle exec rubocop` — **600 files, no offenses**

Chunks note: there is no chunking layer in either repo — units are the retrieval objects, so wiring `unit.lang`/`lang_source` covers chunk consumers with nothing further to hook.