### PR TITLE
Migrate Mirror models to lutaml-model; retire hand-rolled to_h/from_h

### DIFF
--- a/lib/metanorma/mirror/model/container.rb
+++ b/lib/metanorma/mirror/model/container.rb
@@ -4,27 +4,17 @@ module Metanorma
   module Mirror
     module Model
       class Container < Node
-        attr_reader :content
-
-        def initialize(type:, attrs: {}, content: [])
-          super(type: type, attrs: attrs)
-          @content = Array(content)
+        def initialize(type: nil, attrs: {}, content: [], **)
+          super(type: type, attrs: attrs, **)
+          self.content = Array(content)
         end
 
         def container?
           true
         end
 
-        def to_h
-          h = super
-          unless @content.empty?
-            h["content"] = @content.map { |c| serialize_child(c) }
-          end
-          h
-        end
-
         def text_content
-          @content.map do |item|
+          content.map do |item|
             item.is_a?(String) ? item : item.text_content
           end.join
         end
@@ -32,13 +22,26 @@ module Metanorma
         def accept_rewriter(rewriter)
           rewriter.rewrite_container(self)
         end
+      end
 
-        private
+      # content is declared after the sibling node classes exist: the
+      # union member list references Container itself, and lutaml-model
+      # resolves union members eagerly at declaration time. Deserialized
+      # children dispatch through Factory (the child's shape — content
+      # array vs leaf vs text — picks the class), which is why the union
+      # never receives raw hashes on the way in.
+      class Container
+        attribute :content, [Text, SoftBreak, Leaf, Container, :string],
+                  collection: true, default: -> { [] }
 
-        def serialize_child(child)
-          case child
-          when String then child
-          else child.to_h
+        key_value do
+          map "content", to: :content, render_empty: false,
+                         with: { from: :content_from_mapping }
+        end
+
+        def content_from_mapping(model, value)
+          model.content = Array(value).map do |child|
+            child.is_a?(Hash) ? Factory.from_hash(child) : child
           end
         end
       end

--- a/lib/metanorma/mirror/model/factory.rb
+++ b/lib/metanorma/mirror/model/factory.rb
@@ -3,46 +3,28 @@
 module Metanorma
   module Mirror
     module Model
+      # Semantic dispatcher: the wire's "type" and "content" shape pick
+      # the model class; deserialization itself is the framework's
+      # from_hash on the chosen class.
       class Factory
-        INVALID_INPUT = "Factory.from_h expects a Hash, got %<class>s"
+        INVALID_INPUT = "Factory.from_hash expects a Hash, got %<class>s"
+        MISSING_TYPE = "Factory.from_hash requires a 'type' key, got %<hash>s"
 
-        def self.from_h(hash)
+        def self.from_hash(hash)
           unless hash.is_a?(Hash)
-            raise ArgumentError,
-                  format(INVALID_INPUT, class: hash.class)
+            raise ArgumentError, format(INVALID_INPUT, class: hash.class)
           end
 
-          type = hash["type"]
-
-          case type
-          when "text"
-            build_text(hash)
-          when "soft_break"
-            SoftBreak.new
+          case hash["type"]
+          when "text" then Text.from_hash(hash)
+          when "soft_break" then SoftBreak.from_hash(hash)
           when nil
-            raise ArgumentError,
-                  "Factory.from_h requires a 'type' key, got #{hash.inspect}"
+            raise ArgumentError, format(MISSING_TYPE, hash: hash.inspect)
           else
-            build_node(hash, type)
-          end
-        end
-
-        class << self
-          private
-
-          def build_text(hash)
-            marks = Array(hash["marks"]).map { |m| Mark.from_h(m) }
-            Text.new(text: hash["text"] || "", marks: marks)
-          end
-
-          def build_node(hash, type)
-            content = hash["content"]
-            if content.is_a?(Array)
-              children = content.map { |c| c.is_a?(Hash) ? from_h(c) : c }
-              Container.new(type: type, attrs: hash["attrs"] || {},
-                            content: children)
+            if hash["content"].is_a?(Array)
+              Container.from_hash(hash)
             else
-              Leaf.new(type: type, attrs: hash["attrs"] || {})
+              Leaf.from_hash(hash)
             end
           end
         end

--- a/lib/metanorma/mirror/model/guide.rb
+++ b/lib/metanorma/mirror/model/guide.rb
@@ -3,22 +3,25 @@
 module Metanorma
   module Mirror
     module Model
-      class Guide
-        attr_reader :content, :meta, :title, :document
+      class Guide < Lutaml::Model::Serializable
+        attribute :content, [Container, :string]
+        attribute :meta, :hash, default: -> { {} }
+        attribute :title, :string
 
-        def initialize(content:, meta: {}, title: nil, document: nil)
-          @content = content
-          @meta = meta
-          @title = title
-          @document = document
+        key_value do
+          map "content", to: :content
+          map "meta", to: :meta, render_empty: false
+          map "title", to: :title, render_nil: false
         end
 
-        def to_h
-          h = {}
-          h["content"] = @content.is_a?(Container) ? @content.to_h : @content
-          h["meta"] = @meta unless @meta.nil? || @meta.empty?
-          h["title"] = @title if @title
-          h
+        # the parsed source document rides along for output formats; it
+        # is deliberately outside the serialization contract
+        attr_accessor :document
+
+        def initialize(content: nil, meta: {}, title: nil, document: nil,
+                       **)
+          super(content: content, meta: meta, title: title, **)
+          self.document = document
         end
       end
     end

--- a/lib/metanorma/mirror/model/mark.rb
+++ b/lib/metanorma/mirror/model/mark.rb
@@ -3,49 +3,35 @@
 module Metanorma
   module Mirror
     module Model
-      class Mark
-        attr_reader :type, :attrs
+      class Mark < Lutaml::Model::Serializable
+        attribute :type, :string
+        attribute :attrs, :hash, default: -> { {} }
 
-        def initialize(type:, attrs: {})
-          @type = type
-          @attrs = normalize_attrs(attrs)
+        key_value do
+          map "type", to: :type
+          map "attrs", to: :attrs, render_empty: false
         end
 
-        def to_h
-          h = { "type" => type }
-          h["attrs"] = @attrs.dup unless @attrs.empty?
-          h
+        def initialize(type: nil, attrs: {}, **)
+          # wire keys are strings; handlers build attrs with symbol keys
+          super(type: type, attrs: (attrs || {}).transform_keys(&:to_s), **)
         end
 
         def [](key)
-          @attrs[key.to_s]
+          attrs[key.to_s]
         end
 
         def []=(key, value)
-          @attrs[key.to_s] = value
+          attrs[key.to_s] = value
         end
 
         def set_attr(key, value)
-          @attrs[key.to_s] = value
+          attrs[key.to_s] = value
           self
         end
 
         def fetch(key, default = nil, &)
-          @attrs.fetch(key.to_s, default, &)
-        end
-
-        def self.from_h(hash)
-          return nil unless hash
-
-          new(type: hash["type"], attrs: hash["attrs"] || {})
-        end
-
-        private
-
-        def normalize_attrs(attrs)
-          return {} if attrs.nil?
-
-          attrs.transform_keys(&:to_s)
+          attrs.fetch(key.to_s, default, &)
         end
       end
     end

--- a/lib/metanorma/mirror/model/node.rb
+++ b/lib/metanorma/mirror/model/node.rb
@@ -3,18 +3,21 @@
 module Metanorma
   module Mirror
     module Model
-      class Node
-        attr_reader :type, :attrs
+      class Node < Lutaml::Model::Serializable
+        attribute :type, :string
+        attribute :attrs, :hash, default: -> { {} }
 
-        def initialize(type:, attrs: {})
-          @type = type
-          @attrs = normalize_attrs(attrs)
+        key_value do
+          map "type", to: :type
+          map "attrs", to: :attrs, render_empty: false
         end
 
-        def to_h
-          h = { "type" => type }
-          h["attrs"] = @attrs.dup unless @attrs.empty?
-          h
+        # **options carries framework construction kwargs
+        # (e.g. lutaml_register) through to the base serializer
+        def initialize(type: nil, attrs: {}, **)
+          # wire keys are strings; handlers and the transformer build
+          # attrs with symbol keys
+          super(type: type, attrs: (attrs || {}).transform_keys(&:to_s), **)
         end
 
         def leaf?
@@ -32,14 +35,6 @@ module Metanorma
         def accept_rewriter(_rewriter)
           raise NotImplementedError,
                 "#{self.class}#accept_rewriter not implemented"
-        end
-
-        private
-
-        def normalize_attrs(attrs)
-          return {} if attrs.nil?
-
-          attrs.transform_keys(&:to_s)
         end
       end
     end

--- a/lib/metanorma/mirror/model/soft_break.rb
+++ b/lib/metanorma/mirror/model/soft_break.rb
@@ -3,15 +3,14 @@
 module Metanorma
   module Mirror
     module Model
-      class SoftBreak
-        def type
-          "soft_break"
+      class SoftBreak < Lutaml::Model::Serializable
+        attribute :type, :string, default: -> { "soft_break" }
+
+        key_value do
+          map "type", to: :type, render_default: true
         end
 
-        def to_h
-          { "type" => "soft_break" }
-        end
-
+        # rewriter contract: a soft break carries no attrs or content
         def attrs
           {}
         end

--- a/lib/metanorma/mirror/model/text.rb
+++ b/lib/metanorma/mirror/model/text.rb
@@ -3,26 +3,19 @@
 module Metanorma
   module Mirror
     module Model
-      class Text
-        attr_reader :text, :marks
+      class Text < Lutaml::Model::Serializable
+        attribute :type, :string, default: -> { "text" }
+        attribute :text, :string, default: -> { "" }
+        attribute :marks, Mark, collection: true, default: -> { [] }
 
-        def initialize(text:, marks: [])
-          @text = text.to_s
-          @marks = Array(marks)
-        end
-
-        def type
-          "text"
-        end
-
-        def to_h
-          h = { "type" => "text", "text" => @text }
-          h["marks"] = @marks.map(&:to_h) unless @marks.empty?
-          h
+        key_value do
+          map "type", to: :type, render_default: true
+          map "text", to: :text, render_default: true, render_empty: true
+          map "marks", to: :marks, render_empty: false
         end
 
         def text_content
-          @text
+          text
         end
 
         def accept_rewriter(rewriter)

--- a/lib/metanorma/mirror/output/formats/inline_format.rb
+++ b/lib/metanorma/mirror/output/formats/inline_format.rb
@@ -41,7 +41,7 @@ module Metanorma
 
             warn_missing_bundle unless iife_bundle_exists?
 
-            data_script = "window.METANORMA_DATA = #{safe_json(guide.to_h)};"
+            data_script = "window.METANORMA_DATA = #{safe_json(guide.to_hash)};"
             ssr_body = render_ssr_body(guide)
             head_parts = [build_style(classic_content_css)]
             css_inline = read_css_inline

--- a/lib/metanorma/mirror/rewriter.rb
+++ b/lib/metanorma/mirror/rewriter.rb
@@ -6,7 +6,7 @@ module Metanorma
     # per-type customization. Despite living in the reverse-conversion
     # namespace, this class produces a Model graph (not Metanorma XML) —
     # the output is a fully model-driven representation that can be
-    # serialized via Model#to_h or embedded into HTML output by
+    # serialized via Model#to_hash or embedded into HTML output by
     # Output::Formats::InlineFormat (which renders the source document
     # through the classic Metanorma::Html renderer).
     #

--- a/lib/metanorma/mirror/serialization/json_serializer.rb
+++ b/lib/metanorma/mirror/serialization/json_serializer.rb
@@ -6,20 +6,20 @@ module Metanorma
   module Mirror
     module Serialization
       class JsonSerializer
-        # Every Model::Node (Leaf included) has a data to_h; the former
+        # Every Model::Node (Leaf included) has a data to_hash; the former
         # Container-only guard serialized bare leaves as inspect strings.
         def self.serialize(node)
-          data = node.is_a?(Model::Node) ? node.to_h : node
+          data = node.is_a?(Model::Node) ? node.to_hash : node
           data.to_json
         end
 
         def self.serialize_pretty(node)
-          data = node.is_a?(Model::Node) ? node.to_h : node
+          data = node.is_a?(Model::Node) ? node.to_hash : node
           JSON.pretty_generate(data)
         end
 
         def self.deserialize(json_string)
-          Model::Factory.from_h(JSON.parse(json_string))
+          Model::Factory.from_hash(JSON.parse(json_string))
         end
       end
     end

--- a/lib/metanorma/mirror/serialization/yaml_serializer.rb
+++ b/lib/metanorma/mirror/serialization/yaml_serializer.rb
@@ -7,12 +7,12 @@ module Metanorma
     module Serialization
       class YamlSerializer
         def self.serialize(node)
-          data = node.is_a?(Model::Container) ? node.to_h : node
+          data = node.is_a?(Model::Container) ? node.to_hash : node
           data.to_yaml
         end
 
         def self.deserialize(yaml_string)
-          Model::Factory.from_h(YAML.safe_load(yaml_string))
+          Model::Factory.from_hash(YAML.safe_load(yaml_string))
         end
       end
     end

--- a/spec/metanorma/mirror/model/container_spec.rb
+++ b/spec/metanorma/mirror/model/container_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Metanorma::Mirror::Model::Container do
     child = described_class.new(type: "paragraph", attrs: { id: "p1" })
     container = described_class.new(type: "clause", attrs: { id: "s1" },
                                     content: [child])
-    h = container.to_h
+    h = container.to_hash
     expect(h["type"]).to eq("clause")
     expect(h["attrs"]).to eq("id" => "s1")
     expect(h["content"]).to be_an(Array)
@@ -41,14 +41,14 @@ RSpec.describe Metanorma::Mirror::Model::Container do
 
   it "omits content when empty" do
     container = described_class.new(type: "clause")
-    h = container.to_h
+    h = container.to_hash
     expect(h).not_to have_key("content")
   end
 
   it "serializes string children directly" do
     text = Metanorma::Mirror::Model::Text.new(text: "hello")
     container = described_class.new(type: "paragraph", content: [text])
-    h = container.to_h
+    h = container.to_hash
     expect(h["content"][0]).to eq({ "type" => "text", "text" => "hello" })
   end
 

--- a/spec/metanorma/mirror/model/factory_spec.rb
+++ b/spec/metanorma/mirror/model/factory_spec.rb
@@ -4,50 +4,50 @@ require "spec_helper"
 require "metanorma/mirror"
 
 RSpec.describe Metanorma::Mirror::Model::Factory do
-  describe ".from_h" do
+  describe ".from_hash" do
     it "raises ArgumentError for non-hash input" do
       expect do
-        described_class.from_h("string")
+        described_class.from_hash("string")
       end.to raise_error(ArgumentError, /Hash/)
       expect do
-        described_class.from_h(nil)
+        described_class.from_hash(nil)
       end.to raise_error(ArgumentError, /Hash/)
     end
 
     it "raises ArgumentError when type key is missing" do
       expect do
-        described_class.from_h({})
+        described_class.from_hash({})
       end.to raise_error(ArgumentError, /'type'/)
     end
 
     it "creates Text from text hash" do
-      node = described_class.from_h({ "type" => "text", "text" => "hello" })
+      node = described_class.from_hash({ "type" => "text", "text" => "hello" })
       expect(node).to be_a(Metanorma::Mirror::Model::Text)
       expect(node.text).to eq("hello")
     end
 
     it "creates Text with marks" do
-      node = described_class.from_h({
-                                      "type" => "text",
-                                      "text" => "bold",
-                                      "marks" => [{ "type" => "strong" }],
-                                    })
+      node = described_class.from_hash({
+                                         "type" => "text",
+                                         "text" => "bold",
+                                         "marks" => [{ "type" => "strong" }],
+                                       })
       expect(node.marks.size).to eq(1)
       expect(node.marks[0].type).to eq("strong")
     end
 
     it "creates SoftBreak" do
-      node = described_class.from_h({ "type" => "soft_break" })
+      node = described_class.from_hash({ "type" => "soft_break" })
       expect(node).to be_a(Metanorma::Mirror::Model::SoftBreak)
     end
 
     it "creates Container for nodes with content" do
-      node = described_class.from_h({
-                                      "type" => "clause",
-                                      "attrs" => { "id" => "s1" },
-                                      "content" => [{ "type" => "paragraph",
-                                                      "content" => [] }],
-                                    })
+      node = described_class.from_hash({
+                                         "type" => "clause",
+                                         "attrs" => { "id" => "s1" },
+                                         "content" => [{ "type" => "paragraph",
+                                                         "content" => [] }],
+                                       })
       expect(node).to be_a(Metanorma::Mirror::Model::Container)
       expect(node.type).to eq("clause")
       expect(node.attrs["id"]).to eq("s1")
@@ -56,10 +56,10 @@ RSpec.describe Metanorma::Mirror::Model::Factory do
     end
 
     it "creates Leaf for nodes without content" do
-      node = described_class.from_h({
-                                      "type" => "image",
-                                      "attrs" => { "src" => "img.png" },
-                                    })
+      node = described_class.from_hash({
+                                         "type" => "image",
+                                         "attrs" => { "src" => "img.png" },
+                                       })
       expect(node).to be_a(Metanorma::Mirror::Model::Leaf)
       expect(node.type).to eq("image")
       expect(node.attrs["src"]).to eq("img.png")
@@ -75,8 +75,8 @@ RSpec.describe Metanorma::Mirror::Model::Factory do
           ] },
         ],
       }
-      model = described_class.from_h(hash)
-      restored = model.to_h
+      model = described_class.from_hash(hash)
+      restored = model.to_hash
       expect(restored["type"]).to eq("doc")
       expect(restored["content"][0]["type"]).to eq("paragraph")
       expect(restored["content"][0]["content"][0]["text"]).to eq("Hello")
@@ -84,12 +84,12 @@ RSpec.describe Metanorma::Mirror::Model::Factory do
     end
 
     it "handles string content mixed with nodes" do
-      node = described_class.from_h({
-                                      "type" => "paragraph",
-                                      "content" => ["plain text",
-                                                    { "type" => "text",
-                                                      "text" => "styled" }],
-                                    })
+      node = described_class.from_hash({
+                                         "type" => "paragraph",
+                                         "content" => ["plain text",
+                                                       { "type" => "text",
+                                                         "text" => "styled" }],
+                                       })
       expect(node.content.size).to eq(2)
       expect(node.content[0]).to eq("plain text")
       expect(node.content[1]).to be_a(Metanorma::Mirror::Model::Text)

--- a/spec/metanorma/mirror/model/guide_spec.rb
+++ b/spec/metanorma/mirror/model/guide_spec.rb
@@ -32,14 +32,14 @@ RSpec.describe Metanorma::Mirror::Model::Guide do
   it "defaults document to nil and never serializes it" do
     expect(described_class.new(content: nil).document).to be_nil
     guide = described_class.new(content: nil, document: Object.new)
-    expect(guide.to_h).not_to have_key("document")
+    expect(guide.to_hash).not_to have_key("document")
   end
 
   it "serializes to hash" do
     doc = Metanorma::Mirror::Model::Container.new(type: "doc")
     guide = described_class.new(content: doc, meta: { "flavor" => "iso" },
                                 title: "Doc")
-    h = guide.to_h
+    h = guide.to_hash
     expect(h["content"]["type"]).to eq("doc")
     expect(h["meta"]["flavor"]).to eq("iso")
     expect(h["title"]).to eq("Doc")

--- a/spec/metanorma/mirror/model/leaf_spec.rb
+++ b/spec/metanorma/mirror/model/leaf_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Metanorma::Mirror::Model::Leaf do
 
   it "serializes to hash without content" do
     leaf = described_class.new(type: "image", attrs: { src: "img.png" })
-    h = leaf.to_h
+    h = leaf.to_hash
     expect(h).to eq({ "type" => "image", "attrs" => { "src" => "img.png" } })
   end
 

--- a/spec/metanorma/mirror/model/mark_spec.rb
+++ b/spec/metanorma/mirror/model/mark_spec.rb
@@ -18,28 +18,30 @@ RSpec.describe Metanorma::Mirror::Model::Mark do
 
   it "serializes to hash" do
     mark = described_class.new(type: "emphasis")
-    expect(mark.to_h).to eq({ "type" => "emphasis" })
+    expect(mark.to_hash).to eq({ "type" => "emphasis" })
   end
 
   it "omits attrs when empty" do
     mark = described_class.new(type: "emphasis")
-    expect(mark.to_h).not_to have_key("attrs")
+    expect(mark.to_hash).not_to have_key("attrs")
   end
 
-  describe ".from_h" do
+  describe ".from_hash" do
     it "creates mark from hash" do
-      mark = described_class.from_h({ "type" => "link",
-                                      "attrs" => { "href" => "http://x.co" } })
+      mark = described_class.from_hash({ "type" => "link",
+                                         "attrs" => { "href" => "http://x.co" } })
       expect(mark.type).to eq("link")
       expect(mark.attrs["href"]).to eq("http://x.co")
     end
 
-    it "returns nil for nil input" do
-      expect(described_class.from_h(nil)).to be_nil
+    it "rejects nil input" do
+      # nil is not a wire value; the framework owns the contract
+      expect { described_class.from_hash(nil) }
+        .to raise_error(Lutaml::Model::InvalidFormatError)
     end
 
     it "defaults attrs to empty hash" do
-      mark = described_class.from_h({ "type" => "emphasis" })
+      mark = described_class.from_hash({ "type" => "emphasis" })
       expect(mark.attrs).to eq({})
     end
   end
@@ -87,12 +89,12 @@ RSpec.describe Metanorma::Mirror::Model::Mark do
   end
 
   describe "round-trip" do
-    it "to_h then from_h yields equivalent mark" do
+    it "to_hash then from_hash yields equivalent mark" do
       original = described_class.new(type: "link",
                                      attrs: {
                                        "href" => "http://x.co", "title" => "X"
                                      })
-      restored = described_class.from_h(original.to_h)
+      restored = described_class.from_hash(original.to_hash)
       expect(restored.type).to eq(original.type)
       expect(restored.attrs).to eq(original.attrs)
     end

--- a/spec/metanorma/mirror/model/node_spec.rb
+++ b/spec/metanorma/mirror/model/node_spec.rb
@@ -28,13 +28,13 @@ RSpec.describe Metanorma::Mirror::Model::Node do
 
   it "serializes to hash" do
     node = described_class.new(type: "clause", attrs: { id: "s1" })
-    h = node.to_h
+    h = node.to_hash
     expect(h).to eq({ "type" => "clause", "attrs" => { "id" => "s1" } })
   end
 
   it "omits attrs when empty" do
     node = described_class.new(type: "clause")
-    expect(node.to_h).to eq({ "type" => "clause" })
+    expect(node.to_hash).to eq({ "type" => "clause" })
   end
 
   it "is not a leaf or container by default" do

--- a/spec/metanorma/mirror/model/soft_break_spec.rb
+++ b/spec/metanorma/mirror/model/soft_break_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Metanorma::Mirror::Model::SoftBreak do
 
   it "serializes to hash" do
     sb = described_class.new
-    expect(sb.to_h).to eq({ "type" => "soft_break" })
+    expect(sb.to_hash).to eq({ "type" => "soft_break" })
   end
 
   it "has empty attrs and content" do

--- a/spec/metanorma/mirror/model/text_spec.rb
+++ b/spec/metanorma/mirror/model/text_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Metanorma::Mirror::Model::Text do
   it "serializes to hash with marks" do
     mark = Metanorma::Mirror::Model::Mark.new(type: "strong")
     text = described_class.new(text: "bold", marks: [mark])
-    h = text.to_h
+    h = text.to_hash
     expect(h).to eq({
                       "type" => "text",
                       "text" => "bold",
@@ -39,7 +39,7 @@ RSpec.describe Metanorma::Mirror::Model::Text do
 
   it "omits marks when empty" do
     text = described_class.new(text: "plain")
-    h = text.to_h
+    h = text.to_hash
     expect(h).not_to have_key("marks")
   end
 

--- a/spec/metanorma/mirror/rewriter_spec.rb
+++ b/spec/metanorma/mirror/rewriter_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Metanorma::Mirror::Rewriter do
   let(:transformer) { described_class.new }
 
   def container_from(hash)
-    Metanorma::Mirror::Model::Factory.from_h(hash)
+    Metanorma::Mirror::Model::Factory.from_hash(hash)
   end
 
   describe "#call" do

--- a/spec/metanorma/mirror/roundtrip_spec.rb
+++ b/spec/metanorma/mirror/roundtrip_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Metanorma::Mirror::Rewriter do
   end
 
   let(:complex_doc) do
-    Metanorma::Mirror::Model::Factory.from_h(complex_doc_hash)
+    Metanorma::Mirror::Model::Factory.from_hash(complex_doc_hash)
   end
 
   describe "mirror model round-trip through serialization" do
@@ -113,7 +113,7 @@ RSpec.describe Metanorma::Mirror::Rewriter do
           },
         ],
       }
-      doc = Metanorma::Mirror::Model::Factory.from_h(doc_hash)
+      doc = Metanorma::Mirror::Model::Factory.from_hash(doc_hash)
 
       json = Metanorma::Mirror::Serialization::JsonSerializer.serialize(doc)
       restored = Metanorma::Mirror::Serialization::JsonSerializer.deserialize(json)
@@ -131,7 +131,7 @@ RSpec.describe Metanorma::Mirror::Rewriter do
           { "type" => "bibliography", "content" => [] },
         ],
       }
-      doc = Metanorma::Mirror::Model::Factory.from_h(doc_hash)
+      doc = Metanorma::Mirror::Model::Factory.from_hash(doc_hash)
 
       yaml = Metanorma::Mirror::Serialization::YamlSerializer.serialize(doc)
       restored = Metanorma::Mirror::Serialization::YamlSerializer.deserialize(yaml)

--- a/spec/metanorma/mirror/serialization_spec.rb
+++ b/spec/metanorma/mirror/serialization_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Metanorma::Mirror::Serialization::JsonSerializer do
   end
 
   let(:node) do
-    Metanorma::Mirror::Model::Factory.from_h(node_hash)
+    Metanorma::Mirror::Model::Factory.from_hash(node_hash)
   end
 
   describe ".serialize" do
@@ -110,7 +110,7 @@ RSpec.describe Metanorma::Mirror::Serialization::YamlSerializer do
   end
 
   let(:node) do
-    Metanorma::Mirror::Model::Factory.from_h(node_hash)
+    Metanorma::Mirror::Model::Factory.from_hash(node_hash)
   end
 
   describe ".serialize" do


### PR DESCRIPTION
## What

Retires the last hand-rolled serialization fleet in this repo: the Mirror
models (Node/Leaf/Container/Text/SoftBreak/Guide/Mark + Factory) are now
lutaml-model Serializables with key_value mappings. Every def to_h / from_h
is deleted; models keep only behavior (rewriter visitor, text_content,
mutable mark attrs, the unserialized Guide#document attachment).

Mechanics:
- mixed content via Type::Union collections, with :string as the last
  (catch-all) member, declared in a reopen because the member list
  references Container itself and lutaml resolves members eagerly
- the Factory-driven child dispatch (type key + content shape picks the
  class) lives in the sanctioned mapping caster (with: { from: })
- constructors normalize symbol-keyed attrs to the wire's string keys and
  forward framework construction kwargs (lutaml_register)
- rendering parity pins: empty-string text and defaulted type are always
  emitted (render_default/render_empty), empty attrs/marks/content omitted
- Factory renamed from_h -> from_hash; it now only performs semantic class
  dispatch, deserialization is each class's framework from_hash

## Proof of wire stability

Exporting the ISO fixture on main and on this branch produces byte-identical
units.jsonl (117 units, content hashes unchanged) and a manifest identical
modulo its timestamp. Mirror suite 296/0; full suite 976/0; rubocop clean.

Closes TODO.restructure/16 locally.
