### PR TITLE
Parse with moxml 0.5 + leptris: 1.9x faster model parse, 22% less RSS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,6 @@ gem "pubid", ">= 2.0.0.pre.alpha.9"
 if ENV["METANORMA_CI_EDGE"]
   gem "canon", github: "lutaml/canon", branch: "main"
   gem "mml", github: "plurimath/mml", branch: "main"
-  gem "moxml", github: "lutaml/moxml", branch: "main"
 elsif ENV["METANORMA_DEV_LOCAL"]
   gem "canon", path: "../../lutaml/canon"
   gem "mml", path: "../../plurimath/mml"
@@ -40,7 +39,12 @@ end
 
 gem "nokogiri"
 # 0.8.20 yanked; keep the lock below it (github/path pins above override)
-gem "lutaml-model", "~> 0.8.0", "< 0.8.20"
+# 0.8.20 was yanked; 0.8.22+ pairs with moxml 0.5 whose preferred
+# adapter is leptris (fastest on every measured op per lutaml/moxml#96)
+gem "leptris", "~> 1.9"
+gem "lutaml-model", "~> 0.8.0", ">= 0.8.22", "< 0.9"
+gem "moxml", "~> 0.5.30"
+gem "omml", github: "plurimath/omml", branch: "moxml-0.5-range" # TEMPORARY: moxml-0.5 range (plurimath/omml#11); flip to released version
 gem "rake", "~> 13.0"
 gem "rdoc"
 gem "rspec", "~> 3.0"


### PR DESCRIPTION
## What

Performance/memory: the XML layer moves to moxml 0.5 with the leptris
adapter (leptris-ruby), via lutaml-model 0.8.22 (moxml ~> 0.5).

moxml 0.5's preferred adapter IS leptris (lutaml/moxml#96: fastest on
every measured operation) — it engages automatically once leptris is in
the bundle; verified active at runtime.

## Measured (ISO fixture, arm64-darwin)

| workload | before (nokogiri / moxml 0.1) | after (leptris / moxml 0.5) | |
|---|---|---|---|
| 20x document model parse | 30.91s | 16.40s | 1.9x |
| 5x full MKO export | 34.08s | 26.52s | 1.3x |
| RSS after export runs | 625MB | 487MB | -22% |

## Unblocking

omml 0.2.5 capped moxml < 0.2, making the graph unsolvable with
lutaml-model 0.8.22. This branch pins plurimath/omml@moxml-0.5-range
(plurimath/omml#11 — one-line range widening) TEMPORARILY; flip to the
released version when it ships.

Stacked on #59 (mirror gem consumption). Full suite 875/0 on the
leptris backend; rubocop clean.
