### PR TITLE
Stems linearize a single form in plain text (fixes #51)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,9 @@ gem "nokogiri"
 # 0.8.20 was yanked; 0.8.22+ pairs with moxml 0.5 whose preferred
 # adapter is leptris (fastest on every measured op per lutaml/moxml#96)
 gem "leptris", "~> 1.9"
-gem "lutaml-model", "~> 0.8.0", ">= 0.8.22", "< 0.9"
+# TEMPORARY pin: the json 3.0 to_json fix (lutaml-model#769) — flip to
+# the released version when it ships.
+gem "lutaml-model", github: "lutaml/lutaml-model", branch: "fix/767-json-register-kwarg"
 gem "moxml", "~> 0.5.30"
 gem "omml", github: "plurimath/omml", branch: "moxml-0.5-range" # TEMPORARY: moxml-0.5 range (plurimath/omml#11); flip to released version
 gem "rake", "~> 13.0"

--- a/lib/metanorma/html/concerns/text_extraction.rb
+++ b/lib/metanorma/html/concerns/text_extraction.rb
@@ -9,55 +9,129 @@ module Metanorma
       # attributes directly on the model — never strips tags from
       # rendered HTML.
       module TextExtraction
+        # Invisible MathML operators and joiners (word joiner, invisible
+        # times / function application, zero-width space): markup, not
+        # display text.
+        INVISIBLE_MATH_CHARS = "\u2060\u2061\u2062\u2063\u2064\u200b"
+
+        # The quoted unitsml(...) macro reference names a unit symbol;
+        # its linear form is the symbol itself ("unitsml(mV/V)" ->
+        # "mV/V"). One nesting level for grouped exponents.
+        UNITSML_MACRO =
+          /"?unitsml\(([^()]*(?:\([^()]*\)[^()]*)*)\)"?/
+
         def extract_plain_text(node)
           return node.to_s if node.is_a?(String)
           return extract_text_value(node).to_s unless node.is_a?(Lutaml::Model::Serializable)
 
-          parts = []
-          xml_mapping = node.class.mappings_for(:xml, node.lutaml_register)
+          # nil = not a populated stem (e.g. a semx autonum slice also
+          # declares these attributes): fall through to the walk.
+          stem = stem_text(node)
+          return stem unless stem.nil?
 
-          if node.element_order.is_a?(Array) && xml_mapping
-            element_to_attr =
-              Renderers::ElementOrderTraversal.element_to_attr_map(xml_mapping)
-
-            indices = Hash.new(0)
-            node.element_order.each do |el|
-              next unless el.is_a?(Lutaml::Xml::Element)
-
-              if el.text?
-                parts << el.text_content.to_s
-              elsif el.name == "tab"
-                parts << " "
-              # rubocop:disable Lint/DuplicateBranch
-              elsif el.name == "br"
-                parts << " "
-              # rubocop:enable Lint/DuplicateBranch
-              elsif el.element?
-                attr_name = element_to_attr[el.name]
-                if attr_name
-                  coll = node.public_send(attr_name)
-                  obj = if coll.is_a?(Array)
-                          idx = indices[attr_name]
-                          indices[attr_name] += 1
-                          coll[idx]
-                        else
-                          coll
-                        end
-                  text = extract_plain_text(obj)
-                  parts << (text.empty? ? " " : text)
-                elsif el.name == "span"
-                  parts << " "
-                end
-              end
-            end
-          end
-
+          parts = ordered_content_parts(node)
           if parts.join.strip.empty?
             t = safe_attr(node, :text)
             parts << (t.is_a?(Array) ? t.join : t.to_s) if t
           end
 
           parts.join.strip.gsub(" ", " ")
+        end
+
+        def ordered_content_parts(node)
+          return [] unless node.element_order.is_a?(Array)
+
+          xml_mapping = node.class.mappings_for(:xml, node.lutaml_register)
+          return [] unless xml_mapping
+
+          element_to_attr =
+            Renderers::ElementOrderTraversal.element_to_attr_map(xml_mapping)
+
+          parts = []
+          indices = Hash.new(0)
+          node.element_order.each do |el|
+            next unless el.is_a?(Lutaml::Xml::Element)
+
+            if el.text?
+              parts << el.text_content.to_s
+            elsif el.name == "tab"
+              parts << " "
+            # rubocop:disable Lint/DuplicateBranch
+            elsif el.name == "br"
+              parts << " "
+            # rubocop:enable Lint/DuplicateBranch
+            elsif el.element?
+              # The rendered twin of an already-walked semantic stem:
+              # presentation XML carries both forms; extracting both
+              # duplicates the math text (#51).
+              next if el.name == "fmt-stem" && semantic_stems?(node)
+
+              attr_name = element_to_attr[el.name]
+              if attr_name
+                coll = node.public_send(attr_name)
+                obj = if coll.is_a?(Array)
+                        idx = indices[attr_name]
+                        indices[attr_name] += 1
+                        coll[idx]
+                      else
+                        coll
+                      end
+                text = extract_plain_text(obj)
+                parts << (text.empty? ? " " : text)
+              elsif el.name == "span"
+                parts << " "
+              end
+            end
+          end
+          parts
+        end
+
+        # A stem (or a semx slice of one) carries up to three
+        # serializations of a single expression: the AsciiMath source,
+        # the MathML rendering, the LaTeX source. Linearizing more than
+        # one concatenates duplicates — "30003000", 'n LCn_{"LC"}'
+        # (#51). Preference: the source linear form, then the MathML
+        # token walk. Returns nil when no form is populated — the node
+        # is then not stem-shaped content (an empty semx slice), and
+        # the caller falls back to the element_order walk.
+        def stem_text(stem)
+          return nil unless math_carrier?(stem)
+
+          populated = false
+          %i[asciimath math latexmath].each do |form|
+            value = safe_attr(stem, form)
+            next if value.nil? || (value.respond_to?(:empty?) && value.empty?)
+
+            populated = true
+            text = if form == :math
+                     Array(value).map { |m| extract_plain_text(m) }.join(" ")
+                   else
+                     extract_text_value(value)
+                   end
+            text = normalize_math_text(text)
+            return text unless text.empty?
+          end
+          populated ? "" : nil
+        end
+
+        # Duck-typed stem check: any model declaring both an asciimath
+        # and a math attribute serializes one expression in multiple
+        # forms (StemInlineElement, StemElement, SemxElement).
+        def math_carrier?(node)
+          attrs = node.class.attributes
+          attrs.key?(:asciimath) && attrs.key?(:math)
+        end
+
+        def semantic_stems?(node)
+          stems = safe_attr(node, :stem)
+          stems.is_a?(Array) ? stems.any? : !stems.nil?
+        end
+
+        def normalize_math_text(text)
+          text.to_s
+            .tr(INVISIBLE_MATH_CHARS, "")
+            .gsub(UNITSML_MACRO) { Regexp.last_match(1) }
+            .strip
         end
 
         def extract_text_value(val)

--- a/spec/metanorma/document/components/tables/text_table_cell_spec.rb
+++ b/spec/metanorma/document/components/tables/text_table_cell_spec.rb
@@ -31,4 +31,56 @@ RSpec.describe Metanorma::Document::Components::Tables do
     )
     expect(cell.to_xml).to include("stem")
   end
+
+  # #51: a stem carries the MathML rendering AND the AsciiMath source
+  # of one expression — linearizing both concatenates duplicates.
+  it "linearizes one stem form when math and asciimath both parse" do
+    cell = described_class::TextTableCell.from_xml(
+      '<td>Class C, <stem type="MathML"><math><mstyle><mn>3000</mn>' \
+      "</mstyle></math><asciimath>3000</asciimath></stem> intervals</td>",
+    )
+
+    expect(Metanorma::Document::PlainText.call(cell))
+      .to eq("Class C, 3000 intervals")
+  end
+
+  it "unwraps the quoted unitsml macro to the unit symbol" do
+    cell = described_class::TextTableCell.from_xml(
+      '<td>(<stem type="MathML"><math><mrow><mi>mV</mi></mrow></math>' \
+      '<asciimath>"unitsml(mV/V)"</asciimath></stem> or counts)</td>',
+    )
+
+    expect(Metanorma::Document::PlainText.call(cell))
+      .to eq("(mV/V or counts)")
+  end
+
+  it "falls back to the MathML token walk for math-only stems" do
+    cell = described_class::TextTableCell.from_xml(
+      "<td><stem type=\"MathML\"><math><mi>v</mi></math></stem></td>",
+    )
+
+    expect(Metanorma::Document::PlainText.call(cell)).to eq("v")
+  end
+
+  # Presentation XML carries the semantic stem and its rendered
+  # fmt-stem twin — the twin must not duplicate the math text.
+  it "skips the fmt-stem rendered twin when the semantic stem parsed" do
+    cell = described_class::TextTableCell.from_xml(
+      '<td><stem type="AsciiMath"><asciimath>x</asciimath></stem>' \
+      '<fmt-stem type="AsciiML"><semx element="stem" source="_s1">' \
+      "<asciimath>x</asciimath></semx></fmt-stem></td>",
+    )
+
+    expect(Metanorma::Document::PlainText.call(cell)).to eq("x")
+  end
+
+  # semx declares stem attributes for stem slices; an autonum slice
+  # populates none of them and must keep the plain text walk.
+  it "extracts semx autonum fragments that carry no math forms" do
+    cell = described_class::TextTableCell.from_xml(
+      '<td>see <semx element="autonum" source="_t1">7.2.1</semx></td>',
+    )
+
+    expect(Metanorma::Document::PlainText.call(cell)).to eq("see 7.2.1")
+  end
 end


### PR DESCRIPTION
Fixes #51.

## Root cause

A `<stem>` carries **both** the MathML rendering and the AsciiMath source of one expression (semantic and presentation XML both):

```xml
<stem type="MathML"><math><mn>3000</mn></math><asciimath>3000</asciimath></stem>
```

The `extract_plain_text` element_order walk extracted **both** forms and concatenated them, producing exactly the reported artifacts in TablePayload rows (and every other plain-text channel — titles, captions, summaries):

- `30003000` — math `3000` + asciimath `3000`
- `n LCn_{"LC"}` — MathML subscript token walk + asciimath linear form
- `mV ⁢ V − 1"unitsml(mV/V)"` — MathML token walk (with invisible operators) + the quoted unitsml macro reference

## Fix (`TextExtraction`)

1. **One form per stem**: `extract_plain_text` claims populated stems and linearizes a single form — asciimath (the source linear form) → MathML token walk → latexmath. Returns `nil` for a node that declares but populates none of them (e.g. an `<semx element="autonum">7.2.1</semx>` slice), falling through to the normal walk.
2. **Markup is not display text**: the quoted `unitsml(...)` macro reference normalizes to the unit symbol (`"unitsml(mV/V)"` → `mV/V`); invisible MathML operators/joiners (U+2060–U+2064, ZWSP) are stripped.
3. **fmt-stem twins skipped**: presentation XML carries the semantic stem and its rendered `fmt-stem` clone; the twin no longer duplicates the math text when the semantic stem parsed.

The markup itself stays available separately in `mirror` (NativeModels) per the issue's side-channel expectation — rows are now display text only.

## Verification

- Real fixture `mn-samples-oiml r060/3`: the reported rows now read `n_{"LC"}`, `E_{"max"}`, `(mV/V or counts)`; no `unitsml`, invisible-operator, or doubled-value fragments anywhere in units.jsonl table rows. (The `…` + ZWSP sequences in two R 60-2 rows are authored in the source XML — left faithful.)
- New specs: single-form linearization, unitsml unwrap, math-only fallback, fmt-stem twin skip, semx autonum passthrough.
- Full suite 880/0, rubocop clean on changed files.
